### PR TITLE
delete vm button removed from admin view

### DIFF
--- a/app/controllers/atmosphere/admin/virtual_machines_controller.rb
+++ b/app/controllers/atmosphere/admin/virtual_machines_controller.rb
@@ -22,11 +22,6 @@ class Atmosphere::Admin::VirtualMachinesController < Atmosphere::Admin::Applicat
     redirect_to admin_virtual_machines_url
   end
 
-  def destroy
-    @virtual_machine.destroy
-    redirect_to admin_virtual_machines_url, notice: 'Virtual machine was successfully destroyed.'
-  end
-
   private
     def virtual_machine_params
       params.require(:virtual_machine).permit(:virtual_machine_template_id, :name, {appliance_ids: []})

--- a/app/views/atmosphere/admin/virtual_machines/index.html.haml
+++ b/app/views/atmosphere/admin/virtual_machines/index.html.haml
@@ -42,6 +42,3 @@
               = link_to save_as_template_admin_virtual_machine_path(virtual_machine), method: :post,
                 class: 'btn btn-success btn-xs', title: t('virtual_machines.save') do
                 =icon 'save'
-              = link_to admin_virtual_machine_path(virtual_machine), method: :delete, data: { confirm: t('are_you_sure') },
-                class: 'btn btn-danger btn-xs', title: t('virtual_machines.destroy') do
-                =icon 'trash-o'


### PR DESCRIPTION
Delete button was removed from the view and destroy action in `Atmosphere::Admin::VirtualMachinesController` class.

/cc @paoolo, @nowakowski 
