### PR TITLE
Authorization logic moved from ApplianceCreator into cancan

### DIFF
--- a/app/abilities/atmosphere/appliance_ability_builder.rb
+++ b/app/abilities/atmosphere/appliance_ability_builder.rb
@@ -8,7 +8,9 @@ module Atmosphere
           Appliance, appliance_set: { user_id: user.id }
 
       can :create, Appliance do |appl|
-        appl.appliance_set.user_id == user.id && can_start?(appl)
+        appl.owned_by?(user) &&
+          appl.appliance_type.appropriate_for?(appl.appliance_set) &&
+            can_start?(appl)
       end
 
       can :reboot, Appliance, appliance_set: {

--- a/app/models/atmosphere/appliance.rb
+++ b/app/models/atmosphere/appliance.rb
@@ -125,6 +125,10 @@ module Atmosphere
         strategy_class.new(self)
       end
 
+    def owned_by?(user)
+      appliance_set.user_id == user.id
+    end
+
     private
 
     def assign_default_fund

--- a/app/models/atmosphere/appliance_set.rb
+++ b/app/models/atmosphere/appliance_set.rb
@@ -63,7 +63,11 @@ module Atmosphere
         includes(appliances: { deployments: { virtual_machine: :virtual_machine_flavor } }).references(appliances: { deployments: { virtual_machine: :virtual_machine_flavor } })}
 
     def production?
-      not appliance_set_type.development?
+      !appliance_set_type.development?
+    end
+
+    def development?
+      appliance_set_type.development?
     end
   end
 end

--- a/app/models/atmosphere/appliance_type.rb
+++ b/app/models/atmosphere/appliance_type.rb
@@ -147,6 +147,14 @@ module Atmosphere
       visible_to.developer?
     end
 
+    def appropriate_for?(appliance_set)
+      case visible_to.to_sym
+      when :owner then appliance_set.user == author
+      when :developer then appliance_set.appliance_set_type.development?
+      else true
+      end
+    end
+
     private
 
     def self.appliance_type_attributes(appliance, overwrite)

--- a/app/services/atmosphere/appliance_creator.rb
+++ b/app/services/atmosphere/appliance_creator.rb
@@ -1,6 +1,5 @@
 module Atmosphere
   class ApplianceCreator
-
     attr_reader :appliance
 
     def initialize(params, delegated_auth)
@@ -9,16 +8,10 @@ module Atmosphere
       @delegated_auth = delegated_auth
     end
 
-    def create!
-      check_for_at_instantiation_possibility!
-
-      appliance.transaction do
-        apply_preferences
-        init_appliance_configuration
-        init_billing
-
-        appliance.save!
-      end
+    def build
+      apply_preferences
+      init_appliance_configuration
+      init_billing
 
       appliance
     end
@@ -28,7 +21,7 @@ module Atmosphere
     attr_reader :params, :delegated_auth
 
     def create_params
-      c_params = production? ? prod_params : dev_params
+      c_params = development? ? dev_params : prod_params
 
       at = config_template.appliance_type
 
@@ -43,20 +36,18 @@ module Atmosphere
     def prod_params
       opt_policy_params = {}
       opt_policy_params[:vms] = params[:vms]
-      prod_params = params.permit(
-        :appliance_set_id,
-        :name, :description,
-        :compute_site_ids)
+      prod_params = params.permit(:appliance_set_id,
+                                  :name, :description,
+                                  :compute_site_ids)
       prod_params[:optimization_policy_params] = opt_policy_params
       prod_params
     end
 
     def dev_params
-      params.permit(
-        :appliance_set_id,
-        :user_key_id,
-        :name, :description,
-        :compute_site_ids)
+      params.permit(:appliance_set_id,
+                    :user_key_id,
+                    :name, :description,
+                    :compute_site_ids)
     end
 
     def allowed_compute_sites
@@ -68,40 +59,34 @@ module Atmosphere
     end
 
     def apply_preferences
-      preferences && appliance.create_dev_mode_property_set(preferences)
-    end
-
-    def init_billing
-      # Add Time.now.utc() as prepaid_until - this effectively means that the appliance is unpaid.
-      # The requestor must bill this new appliance prior to exposing it to the end user.
-      appliance.prepaid_until = Time.now.utc
+      appliance.create_dev_mode_property_set(preferences) if development?
     end
 
     def preferences
-      params.permit(dev_mode_property_set: [:preference_memory, :preference_cpu, :preference_disk])[:dev_mode_property_set] unless production?
+      prefs = params.permit(
+                dev_mode_property_set: [
+                  :preference_memory,
+                  :preference_cpu,
+                  :preference_disk
+                ])
+      prefs[:dev_mode_property_set] || {}
+    end
+
+    def init_billing
+      # Add Time.now.utc() as prepaid_until - this effectively means
+      # that the appliance is unpaid.
+      # The requestor must bill this new appliance prior to exposing
+      # it to the end user.
+      appliance.prepaid_until = Time.now.utc
     end
 
     def init_appliance_configuration
-      appliance.appliance_configuration_instance = configuration_instance
+      appliance.appliance_configuration_instance =
+        ApplianceConfigurationInstance.get(config_template, config_params)
     end
 
-    def check_for_at_instantiation_possibility!
-      raise CanCan::AccessDenied unless can_create_appliance?
-    end
-
-    def can_create_appliance?
-      type = appliance.appliance_type
-      visible_to = type.visible_to
-
-      case visible_to.to_sym
-        when :owner     then appliance.appliance_set.user == type.author
-        when :developer then appliance.appliance_set.appliance_set_type.development?
-        else true
-      end
-    end
-
-    def production?
-      appliance_set.production?
+    def development?
+      appliance_set.development?
     end
 
     def appliance_set
@@ -113,15 +98,12 @@ module Atmosphere
     end
 
     def config_template
-      @config_template ||= ApplianceConfigurationTemplate.find(config_template_id)
+      @config_template ||=
+        ApplianceConfigurationTemplate.find(config_template_id)
     end
 
     def config_template_id
       params[:configuration_template_id]
-    end
-
-    def configuration_instance
-      @config_instance ||= ApplianceConfigurationInstance.get(config_template, config_params)
     end
 
     def config_params

--- a/spec/abilities/atmosphere/appliance_ability_builder_spec.rb
+++ b/spec/abilities/atmosphere/appliance_ability_builder_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+describe Atmosphere::ApplianceAbilityBuilder do
+  let(:user) { build(:user) }
+  let(:pdp) { double('pdp') }
+  let(:ability) { Atmosphere::Ability.new(user) }
+  let(:at) { build(:appliance_type, visible_to: :all) }
+
+  before do
+    allow(Atmosphere).to receive(:at_pdp).with(user).and_return(pdp)
+  end
+
+  it 'cannot start dev AT in production mode' do
+    at = build(:appliance_type, visible_to: :developer)
+    appl = start_appl(:portal, at)
+
+    expect(ability.can?(:create, appl)).to be_falsy
+  end
+
+  it 'cannot start not owned private AT' do
+    at = build(:appliance_type, visible_to: :owner)
+    appl = start_appl(:portal, at)
+
+    expect(ability.can?(:create, appl)).to be_falsy
+  end
+
+  it 'starts appl in production when pdp allows it' do
+    appl = start_appl(:portal, at, :can_start_in_production?, true)
+
+    expect(ability.can?(:create, appl)).to be_truthy
+  end
+
+  it 'does not allow to start AT in production when pdp does not allow it' do
+    appl = start_appl(:portal, at, :can_start_in_production?, false)
+
+    expect(ability.can?(:create, appl)).to be_falsy
+  end
+
+  it 'starts appl in development when pdp allows it' do
+    appl = start_appl(:development, at, :can_start_in_development?, true)
+
+    expect(ability.can?(:create, appl)).to be_truthy
+  end
+
+  it 'does not allow to start AT in development when pdp does not allow it' do
+    appl = start_appl(:development, at, :can_start_in_development?, false)
+
+    expect(ability.can?(:create, appl)).to be_falsy
+  end
+
+  def start_appl(type, at, pdp_method_sym = nil, pdp_response = nil)
+    appl = build(:appliance, appliance_set: build_as(type), appliance_type: at)
+    if pdp_method_sym
+      allow(pdp).to receive(pdp_method_sym).with(at).and_return(pdp_response)
+    end
+    appl
+  end
+
+  def build_as(type)
+    as = build(:appliance_set, user: user, appliance_set_type: type)
+    as.user_id = user.id
+    as
+  end
+end

--- a/spec/models/atmosphere/ability_spec.rb
+++ b/spec/models/atmosphere/ability_spec.rb
@@ -12,34 +12,6 @@ describe Atmosphere::Ability do
     user.id = 1
   end
 
-  context 'with appliance' do
-    let(:at) { build(:appliance_type) }
-
-    it 'starts appl in production when pdp allows it' do
-      appl = start_appl(:portal, :can_start_in_production?, true)
-
-      expect(ability.can?(:create, appl)).to be_truthy
-    end
-
-    it 'does not allow to start AT in production when pdp does not allow it' do
-      appl = start_appl(:portal, :can_start_in_production?, false)
-
-      expect(ability.can?(:create, appl)).to be_falsy
-    end
-
-    it 'starts appl in development when pdp allows it' do
-      appl = start_appl(:development, :can_start_in_development?, true)
-
-      expect(ability.can?(:create, appl)).to be_truthy
-    end
-
-    it 'does not allow to start AT in development when pdp does not allow it' do
-      appl = start_appl(:development, :can_start_in_development?, false)
-
-      expect(ability.can?(:create, appl)).to be_falsy
-    end
-  end
-
   context 'with appliance type' do
     let(:at) { build(:appliance_type) }
 
@@ -120,17 +92,5 @@ describe Atmosphere::Ability do
        expect(ability.can?(:update, act)).to be_falsy
        expect(ability.can?(:destroy, act)).to be_falsy
      end
-  end
-
-  def start_appl(type, pdp_method_sym, pdp_response)
-    appl = build(:appliance, appliance_set: build_as(type), appliance_type: at)
-    allow(pdp).to receive(pdp_method_sym).with(at).and_return(pdp_response)
-    appl
-  end
-
-  def build_as(type)
-    as = build(:appliance_set, user: user, appliance_set_type: type)
-    as.user_id = user.id
-    as
   end
 end

--- a/spec/models/atmosphere/appliance_spec.rb
+++ b/spec/models/atmosphere/appliance_spec.rb
@@ -163,4 +163,12 @@ describe Atmosphere::Appliance do
       expect(appl.user_data).to eq 'user_data'
     end
   end
+
+  it 'owned by the user' do
+    user = build(:user)
+    as = build(:appliance_set, user: user)
+    appl = create(:appliance, appliance_set: as)
+
+    expect(appl.owned_by?(user)).to be_truthy
+  end
 end

--- a/spec/models/atmosphere/appliance_type_spec.rb
+++ b/spec/models/atmosphere/appliance_type_spec.rb
@@ -201,4 +201,32 @@ describe Atmosphere::ApplianceType do
 
     expect(at.compute_sites).to eq [active_cs]
   end
+
+  context '#appropriate_for?' do
+    it 'does not allow to use dev appliance in prod appliance set' do
+      at, as = at_and_as(:developer, :portal)
+      dev_as = build(:appliance_set, appliance_set_type: :development)
+
+      expect(at.appropriate_for?(as)).to be_falsy
+      expect(at.appropriate_for?(dev_as)).to be_truthy
+    end
+
+    it 'owner at appropriate only for owner' do
+      at, as = at_and_as(:owner, :portal)
+      user = build(:user)
+      at.author = user
+      as.user = user
+      other_user_as = create(:appliance_set)
+
+      expect(at.appropriate_for?(as)).to be_truthy
+      expect(at.appropriate_for?(other_user_as)).to be_falsy
+    end
+
+    def at_and_as(at_type, as_type)
+      at = build(:appliance_type, visible_to: at_type)
+      as = build(:appliance_set, appliance_set_type: as_type)
+
+      [at, as]
+    end
+  end
 end

--- a/spec/providers/atmosphere/optimization_strategy/manual_spec.rb
+++ b/spec/providers/atmosphere/optimization_strategy/manual_spec.rb
@@ -30,7 +30,8 @@ describe Atmosphere::OptimizationStrategy::Manual do
         }
       )
     creator = Atmosphere::ApplianceCreator.new(created_appl_params, 'dummy-token')
-    appl = creator.create!
+    appl = creator.build
+    appl.save!
 
     manual_policy = Atmosphere::OptimizationStrategy::Manual.new(appl)
 

--- a/spec/services/atmosphere/appliance_creator_spec.rb
+++ b/spec/services/atmosphere/appliance_creator_spec.rb
@@ -12,15 +12,15 @@ describe Atmosphere::ApplianceCreator do
   context 'compute site ids not provided' do
 
     it 'creates appliance with allowed active compute site only' do
-      created_appl_params = ActionController::Parameters
-                              .new(appliance_set_id: as.id,
-                                   configuration_template_id: cfg_tmpl.id)
-      creator = Atmosphere::ApplianceCreator
-                  .new(created_appl_params, 'dummy-token')
+      created_appl_params = ActionController::Parameters.
+                              new(appliance_set_id: as.id,
+                                  configuration_template_id: cfg_tmpl.id)
+      creator = Atmosphere::ApplianceCreator.
+                  new(created_appl_params, 'dummy-token')
 
-      appl = creator.create!
+      appl = creator.build
 
-      expect(appl.compute_sites.count).to eq 1
+      expect(appl.compute_sites).to eq [active_cs]
       expect(appl.compute_sites.first.active).to be true
     end
 
@@ -29,16 +29,16 @@ describe Atmosphere::ApplianceCreator do
   context 'compute site ids provided' do
 
     it 'creates appliance with allowed active compute site only' do
-      created_appl_params = ActionController::Parameters
-                              .new(appliance_set_id: as.id,
-                                   configuration_template_id: cfg_tmpl.id,
-                                   compute_site_ids: [active_cs, inactive_cs])
-      creator = Atmosphere::ApplianceCreator
-                  .new(created_appl_params, 'dummy-token')
+      created_appl_params = ActionController::Parameters.
+                              new(appliance_set_id: as.id,
+                                  configuration_template_id: cfg_tmpl.id,
+                                  compute_site_ids: [active_cs, inactive_cs])
+      creator = Atmosphere::ApplianceCreator.
+                  new(created_appl_params, 'dummy-token')
 
-      appl = creator.create!
+      appl = creator.build
 
-      expect(appl.compute_sites.count).to eq 1
+      expect(appl.compute_sites).to eq [active_cs]
       expect(appl.compute_sites.first.active).to be true
     end
   end
@@ -48,16 +48,16 @@ describe Atmosphere::ApplianceCreator do
            { 'cpu' => 1, 'mem' => 512, 'compute_site_ids' => [1] },
            { 'cpu' => 2, 'mem' => 1024, 'compute_site_ids' => [1] }
           ]
-    created_appl_params = ActionController::Parameters
-                            .new(appliance_set_id: as.id,
-                                 configuration_template_id: cfg_tmpl.id,
-                                 vms: vms)
-      creator = Atmosphere::ApplianceCreator
-                  .new(created_appl_params, 'dummy-token')
+    created_appl_params = ActionController::Parameters.
+                            new(appliance_set_id: as.id,
+                                configuration_template_id: cfg_tmpl.id,
+                                vms: vms)
+    creator = Atmosphere::ApplianceCreator.
+                new(created_appl_params, 'dummy-token')
 
-      appl = creator.create!
+    appl = creator.build
 
-      expect(appl.optimization_policy_params[:vms]).to eq vms
+    expect(appl.optimization_policy_params[:vms]).to eq vms
   end
 
 end


### PR DESCRIPTION
Inside `Atmosphere::ApplianceCreator` logic responsible for create authorization occurs. It was moved into cancan ability. 

Fixes redmine 3207 issue.

/cc @nowakowski, @djchrap, @Nuanda - please take a look. Deployed into `dev` - please test.
