### PR TITLE
Undefined method capture_message fixed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,8 +36,7 @@ end
 
 group :test do
   # gem 'rspec-rails'
-  # gem 'rspec-sidekiq'
-  gem 'rspec-sidekiq', github: 'yelled3/rspec-sidekiq', branch: 'rspec3-beta'
+  gem 'rspec-sidekiq'
   # gem 'shoulda-matchers'
 
   # gem 'factory_girl'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: git://github.com/yelled3/rspec-sidekiq.git
-  revision: e4d2e34dcccfc51bb5b7c67fe06786eaa6c8e0d2
-  branch: rspec3-beta
-  specs:
-    rspec-sidekiq (1.0.0)
-      rspec (>= 3.0.0)
-      sidekiq (>= 2.4.0)
-
 PATH
   remote: .
   specs:
@@ -94,8 +85,8 @@ GEM
       sass (~> 3.2)
     builder (3.2.2)
     cancan (1.6.10)
-    celluloid (0.15.2)
-      timers (~> 1.1.0)
+    celluloid (0.16.0)
+      timers (~> 4.0.0)
     clockwork (1.0.0)
       activesupport
       tzinfo
@@ -112,7 +103,7 @@ GEM
       execjs
     coffee-script-source (1.8.0)
     colored (1.2)
-    connection_pool (2.0.0)
+    connection_pool (2.1.0)
     database_cleaner (1.3.0)
     debug_inspector (0.0.2)
     devise (3.4.0)
@@ -208,6 +199,7 @@ GEM
       railties (>= 4.0.1)
     hashie (3.3.1)
     hike (1.2.3)
+    hitimes (1.2.2)
     i18n (0.6.11)
     inflecto (0.0.2)
     influxdb (0.1.8)
@@ -305,12 +297,12 @@ GEM
       rspec-core (~> 3.1.0)
       rspec-expectations (~> 3.1.0)
       rspec-mocks (~> 3.1.0)
-    rspec-core (3.1.5)
+    rspec-core (3.1.7)
       rspec-support (~> 3.1.0)
     rspec-expectations (3.1.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.1.0)
-    rspec-mocks (3.1.2)
+    rspec-mocks (3.1.3)
       rspec-support (~> 3.1.0)
     rspec-rails (3.1.0)
       actionpack (>= 3.0)
@@ -320,7 +312,10 @@ GEM
       rspec-expectations (~> 3.1.0)
       rspec-mocks (~> 3.1.0)
       rspec-support (~> 3.1.0)
-    rspec-support (3.1.1)
+    rspec-sidekiq (2.0.0)
+      rspec (~> 3.0, >= 3.0.0)
+      sidekiq (>= 2.4.0)
+    rspec-support (3.1.2)
     ruby-progressbar (1.6.0)
     sass (3.2.19)
     sass-rails (4.0.3)
@@ -338,8 +333,8 @@ GEM
     showdown-rails (0.0.4)
       actionpack (>= 3.1)
       railties (>= 3.1)
-    sidekiq (3.2.5)
-      celluloid (= 0.15.2)
+    sidekiq (3.3.0)
+      celluloid (>= 0.16.0)
       connection_pool (>= 2.0.0)
       json
       redis (>= 3.0.6)
@@ -372,7 +367,8 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.4)
     tilt (1.4.1)
-    timers (1.1.0)
+    timers (4.0.1)
+      hitimes
     turbolinks (2.4.0)
       coffee-rails
     tzinfo (1.2.2)
@@ -407,7 +403,7 @@ DEPENDENCIES
   quiet_assets
   rails_best_practices
   rspec-rails
-  rspec-sidekiq!
+  rspec-sidekiq
   shoulda-matchers
   spring
   spring-commands-rspec

--- a/spec/workers/atmosphere/vm_tags_creator_worker_spec.rb
+++ b/spec/workers/atmosphere/vm_tags_creator_worker_spec.rb
@@ -108,7 +108,11 @@ describe Atmosphere::VmTagsCreatorWorker do
         Atmosphere::VmTagsCreatorWorker.new.perform(vm_mock.id, tags_map)
       end
     end
-
   end
 
+  it 'report raven issue when retries exhausted' do
+    Atmosphere::VmTagsCreatorWorker.within_sidekiq_retries_exhausted_block do
+      expect(Raven).to receive(:capture_message)
+    end
+  end
 end


### PR DESCRIPTION
`sidekiq_retries_exhausted` is not able to invoke normal class method.
As a result "undefined method `capture_message` for
Atmosphere::VmTagsCreatorWorker:Class" was thrown. Fix introduces direct
invocation of `Raven.capture_message`.

To test this behavior I have also upgraded `rspec-sidekiq` into stable
released version 2.0.0

Fixes #11

/cc @tbartynski, @nowakowski 
