### PR TITLE
check if vm is not created by monitoring

### DIFF
--- a/app/services/atmosphere/appliance_vms_manager.rb
+++ b/app/services/atmosphere/appliance_vms_manager.rb
@@ -49,12 +49,18 @@ module Atmosphere
 
     def instantiate_vm(tmpl, flavor, name)
       server_id = start_vm_on_cloud(tmpl, flavor, name)
-      vm = appliance.virtual_machines.create(
-          name: name, source_template: tmpl,
-          state: :build, virtual_machine_flavor: flavor,
-          managed_by_atmosphere: true, id_at_site: server_id,
+      vm = VirtualMachine.find_or_initialize_by(
+          id_at_site: server_id,
           compute_site: tmpl.compute_site
         )
+      vm.name = name
+      vm.source_template = tmpl
+      vm.state = :build
+      vm.virtual_machine_flavor = flavor
+      vm.managed_by_atmosphere = true
+      appliance.virtual_machines << vm
+
+      vm.save
 
       if vm.valid?
         appliance_satisfied(vm)

--- a/spec/services/atmosphere/appliance_vms_manager_spec.rb
+++ b/spec/services/atmosphere/appliance_vms_manager_spec.rb
@@ -95,7 +95,7 @@ describe Atmosphere::ApplianceVmsManager do
         name: 'name',
         id: 1,
 
-        virtual_machines: double(create: vm)
+        virtual_machines: double(create: vm, :<< => true)
       )
     end
     let(:tags_mng) { double('tags manager') }
@@ -118,6 +118,17 @@ describe Atmosphere::ApplianceVmsManager do
         {flavor: flavor, name: name, user_data: 'user data', user_key: 'user key'})
           .and_return(vm_creator)
       allow(tags_mng).to receive(:create_tags_for_vm)
+
+      allow(Atmosphere::VirtualMachine).to receive(:find_or_initialize_by).
+        and_return(vm)
+
+      allow(vm).to receive(:name=)
+      allow(vm).to receive(:source_template=)
+      allow(vm).to receive(:state=)
+      allow(vm).to receive(:virtual_machine_flavor=)
+      allow(vm).to receive(:managed_by_atmosphere=)
+      allow(vm).to receive(:save)
+      allow(vm).to receive(:valid?).and_return(true)
     end
 
     context 'when user can afford to spawn VM with selected flavor' do
@@ -128,14 +139,20 @@ describe Atmosphere::ApplianceVmsManager do
 
       it 'creates new VM' do
         allow(vm).to receive(:valid?).and_return(true)
-        expect(appl.virtual_machines).to receive(:create) do |params|
-          expect(params[:name]).to eq name
-          expect(params[:source_template]).to eq tmpl
-          expect(params[:virtual_machine_flavor]).to eq flavor
-          expect(params[:managed_by_atmosphere]).to be_truthy
-          expect(params[:id_at_site]).to eq 'server_id'
-          expect(params[:compute_site]).to eq tmpl.compute_site
-        end.and_return(vm)
+
+        expect(Atmosphere::VirtualMachine).to receive(:find_or_initialize_by).
+          with(id_at_site: 'server_id', compute_site: tmpl.compute_site).
+          and_return(vm)
+
+        expect(vm).to receive(:name=).with(name)
+        expect(vm).to receive(:source_template=).with(tmpl)
+        expect(vm).to receive(:state=).with(:build)
+        expect(vm).to receive(:virtual_machine_flavor=).with(flavor)
+        expect(vm).to receive(:managed_by_atmosphere=).with(true)
+
+        expect(vm).to receive(:save)
+        expect(vm).to receive(:valid?).and_return(true)
+        expect(appl.virtual_machines).to receive(:<<).with(vm)
 
         subject.spawn_vm!(tmpl, flavor, name)
       end


### PR DESCRIPTION
There are situation when between spawning VM on compute site and registering
this machine inside atmosphere DB VM monitoring is triggered. As a conclusion
VM with duplicated `id_at_site` is create, which causes
`Unable to assign VM to appliance` error. Here we are fixing this issue by
checking if VM exists in database or initializing it
(`find_or_initialize`).

@nowakowski This change is deployed into `vph-dev` - please test it and report back
