### PR TITLE
added Atmo prefix to User model class name

### DIFF
--- a/app/models/atmosphere/user_fund.rb
+++ b/app/models/atmosphere/user_fund.rb
@@ -11,7 +11,8 @@
 # Linking table between Users and Funds
 module Atmosphere
   class UserFund < ActiveRecord::Base
-    belongs_to :user
+    belongs_to :user,
+      class_name: 'Atmosphere::User'
 
     belongs_to :fund,
       class_name: 'Atmosphere::Fund'


### PR DESCRIPTION
I found this model class lack namespace. For instance, UserKey uses namespace for the User model class. So I thought I add it here - my local tests shown it works. @nowakowski @mkasztelnik  Is it just a simple omission or the namespace was absent for a reason?
