### PR TITLE
do nothing when VM is already deleted

### DIFF
--- a/app/workers/atmosphere/vm_tags_creator_worker.rb
+++ b/app/workers/atmosphere/vm_tags_creator_worker.rb
@@ -15,7 +15,14 @@ module Atmosphere
     end
 
     def perform(vm_id, tags_map)
-      vm = VirtualMachine.find(vm_id)
+      vm = VirtualMachine.find_by(id: vm_id)
+
+      tag(vm, tags_map) if vm
+    end
+
+    private
+
+    def tag(vm, tags_map)
       cs = vm.compute_site
       if cs.technology == 'openstack'
         tag_vm_on_openstack(vm, cs.cloud_client, tags_map)
@@ -23,8 +30,6 @@ module Atmosphere
         tag_vm_on_amazon(vm, cs.cloud_client, tags_map)
       end
     end
-
-    private
 
     def tag_vm_on_openstack(vm, cloud_client, tags_map)
       if vm.state == 'active'

--- a/spec/workers/atmosphere/vm_tags_creator_worker_spec.rb
+++ b/spec/workers/atmosphere/vm_tags_creator_worker_spec.rb
@@ -12,7 +12,8 @@ describe Atmosphere::VmTagsCreatorWorker do
 
   before do
     allow(cs_mock).to receive(:cloud_client).and_return cloud_client_mock
-    allow(Atmosphere::VirtualMachine).to receive(:find).with(vm_id).and_return(vm_mock)
+    allow(Atmosphere::VirtualMachine).
+      to receive(:find_by).with(id: vm_id).and_return(vm_mock)
     allow(vm_mock).to receive(:id).and_return vm_id
     allow(vm_mock).to receive(:id_at_site).and_return id_at_site
     allow(vm_mock).to receive(:compute_site).and_return cs_mock
@@ -67,6 +68,18 @@ describe Atmosphere::VmTagsCreatorWorker do
       end
 
     end
+  end
+
+  it 'do nothing when VM was already deleted', focus: true do
+    allow(Atmosphere::VirtualMachine).
+      to receive(:find_by).
+      with(id: 'non_existing').
+      and_return(nil)
+
+    expect do
+      Atmosphere::VmTagsCreatorWorker.new.
+        perform('non_existing', tags_map)
+    end.to_not raise_error
   end
 
   context 'inactive vm' do


### PR DESCRIPTION
VM tagging is invoked with some delay (when VM should be already seen by cloud
REST API). As a conclusion there can be a situation when VM tagging is invoked
by user already removed selected VM.

/cc @tbartynski, @nowakowski please take a look

Fixes #23
