### PR TITLE
ignore destroy on cloud not found exception

### DIFF
--- a/app/models/atmosphere/virtual_machine.rb
+++ b/app/models/atmosphere/virtual_machine.rb
@@ -228,7 +228,7 @@ module Atmosphere
         )
       end
     rescue Fog::Compute::OpenStack::NotFound, Fog::Compute::AWS::NotFound
-      logger.info("VM with #{id_at_site} does not exist - continuing")
+      logger.warn("VM with #{id_at_site} does not exist - continuing")
     end
 
     def cant_destroy_non_managed_vm

--- a/app/models/atmosphere/virtual_machine.rb
+++ b/app/models/atmosphere/virtual_machine.rb
@@ -227,6 +227,8 @@ module Atmosphere
           }
         )
       end
+    rescue Fog::Compute::OpenStack::NotFound, Fog::Compute::AWS::NotFound
+      logger.info("VM with #{id_at_site} does not exist - continuing")
     end
 
     def cant_destroy_non_managed_vm

--- a/app/models/atmosphere/virtual_machine_template.rb
+++ b/app/models/atmosphere/virtual_machine_template.rb
@@ -138,9 +138,10 @@ module Atmosphere
 
     def perform_delete_in_cloud
       logger.info "Deleting template #{uuid}"
-      cloud_client = self.compute_site.cloud_client
-      cloud_client.images.destroy self.id_at_site
+      cloud_client.images.destroy id_at_site
       logger.info "Destroyed template #{uuid}"
+    rescue Fog::Compute::OpenStack::NotFound, Fog::Compute::AWS::NotFound
+      logger.info("VMT with #{id_at_site} does not exist - continuing")
     end
 
     private
@@ -183,6 +184,10 @@ module Atmosphere
 
     def cant_destroy_non_managed_vmt
       errors.add :base, 'Virtual Machine Template is not managed by atmosphere' unless managed_by_atmosphere
+    end
+
+    def cloud_client
+      compute_site.cloud_client
     end
 
     def set_version

--- a/app/models/atmosphere/virtual_machine_template.rb
+++ b/app/models/atmosphere/virtual_machine_template.rb
@@ -141,7 +141,7 @@ module Atmosphere
       cloud_client.images.destroy id_at_site
       logger.info "Destroyed template #{uuid}"
     rescue Fog::Compute::OpenStack::NotFound, Fog::Compute::AWS::NotFound
-      logger.info("VMT with #{id_at_site} does not exist - continuing")
+      logger.warn("VMT with #{id_at_site} does not exist - continuing")
     end
 
     private


### PR DESCRIPTION
We should not care about VM, VMT not found exception thrown by compute site when destroying `Atmosphere::VirtualMachine`, `Atmosphere::VirtualMachineTemplate`.

Fixes #50