### PR TITLE
optimization_policy in appliance set serializer

### DIFF
--- a/app/serializers/atmosphere/appliance_set_serializer.rb
+++ b/app/serializers/atmosphere/appliance_set_serializer.rb
@@ -3,7 +3,7 @@
 #
 module Atmosphere
   class ApplianceSetSerializer < ActiveModel::Serializer
-    attributes :id, :name, :priority
+    attributes :id, :name, :priority, :optimization_policy
     attribute :appliance_set_type
   end
 end

--- a/doc/api/appliance_sets.md
+++ b/doc/api/appliance_sets.md
@@ -13,7 +13,8 @@ GET /appliance_sets
       "id": 1,
       "name": "Foobar Appliance Set",
       "priority": 50,
-      "appliance_set_type": "workflow"
+      "appliance_set_type": "workflow",
+      "optimization_policy": "default"
     }, {
       ...
     }
@@ -39,7 +40,8 @@ Parameters:
     "id": 1,
     "name": "Foobar Appliance Set",
     "priority": 50,
-    "appliance_set_type": "workflow"
+    "appliance_set_type": "workflow",
+    "optimization_policy": "manual"
   }
 }
 ```
@@ -60,10 +62,10 @@ Parameters:
     "name": "Foobar Appliance Set",
     "priority": 50,
     "appliance_set_type": "workflow",
-    "optimalization_policy": "manual",
+    "optimization_policy": "manual",
     "appliances": [
-      { 
-        "configuration_template_id": 1, 
+      {
+        "configuration_template_id": 1,
         "params": { "a": "piersza wartosc, "b": "druga wartosc" },
         "vms": [
            { "cpu": 1, "mem": 512, compute_site_ids: [1] }
@@ -86,7 +88,7 @@ Parameters:
     + `vms` (optional) - if `manual` optimization policy is selected (see `optimization_policy` parameter) then this parameter provides a specification of virtual machines that will be spawned for an appliance. The format of this parameter is the an array of hashes. Hash for single virtual machine may contain the following keys:
         + `cpu` (optional) - How many cpu cores are required for a virtual machine.
         + `mem` (optional) - How much RAM memory is required for a virtual machine.
-        + `compute_site_ids` (optional) - An array of ids of compute sites that can be used to host virtual machine. 
+        + `compute_site_ids` (optional) - An array of ids of compute sites that can be used to host virtual machine.
 
 
 

--- a/spec/serializers/atmosphere/appliance_set_serializer_spec.rb
+++ b/spec/serializers/atmosphere/appliance_set_serializer_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe Atmosphere::ApplianceSetSerializer do
+  it 'returns information about set' do
+    as = build(:appliance_set,
+               id: 1,
+               name: 'as',
+               priority: 24,
+               appliance_set_type: :portal,
+               optimization_policy: :manual)
+    serializer = Atmosphere::ApplianceSetSerializer.new(as)
+
+    result = JSON.parse(serializer.to_json)
+
+    expect(result['appliance_set']['id']).to eq 1
+    expect(result['appliance_set']['name']).to eq 'as'
+    expect(result['appliance_set']['priority']).to eq 24
+    expect(result['appliance_set']['appliance_set_type']).to eq 'portal'
+    expect(result['appliance_set']['optimization_policy']).to eq 'manual'
+  end
+end


### PR DESCRIPTION
As @dharezlak noticed `optimization_policy` was not returned by REST API. This PR adds missing field.

/cc @dice-cyfronet/atmo-dev please take a look