### PR TITLE
vm and vmt monitoring intervals from config

### DIFF
--- a/lib/atmosphere.rb
+++ b/lib/atmosphere.rb
@@ -62,8 +62,9 @@ module Atmosphere
   @@optimizer = Struct.new(:max_appl_no).new(5)
 
   mattr_reader :monitoring
-  @@monitoring = Struct.new(:load, :vm, :vmt, :flavor).
-    new(5.minutes, 30.seconds, 1.minute, 120.minutes)
+  @@monitoring = Struct.new(:intervals).new(
+    Struct.new(:load, :vm, :vmt, :flavor).
+      new(5.minutes, 30.seconds, 1.minute, 120.minutes))
 
   mattr_accessor :childhood_age #seconds
   @@childhood_age = 2

--- a/lib/atmosphere.rb
+++ b/lib/atmosphere.rb
@@ -55,14 +55,15 @@ module Atmosphere
   @@config_param = Struct.new(:regexp, :range).new(/\#{\w*}/, 2..-2)
 
   mattr_reader :url_monitoring
-  @@url_monitoring = Struct.new(:unavail_statuses, :pending, :ok, :lost)
-    .new([502], 10, 120, 15)
+  @@url_monitoring = Struct.new(:unavail_statuses, :pending, :ok, :lost).
+    new([502], 10, 120, 15)
 
   mattr_reader :optimizer
   @@optimizer = Struct.new(:max_appl_no).new(5)
 
   mattr_reader :monitoring
-  @@monitoring = Struct.new(:query_interval).new(5)
+  @@monitoring = Struct.new(:load, :vm, :vmt, :flavor).
+    new(5.minutes, 30.seconds, 1.minute, 120.minutes)
 
   mattr_accessor :childhood_age #seconds
   @@childhood_age = 2

--- a/lib/atmosphere/clockwork.rb
+++ b/lib/atmosphere/clockwork.rb
@@ -3,21 +3,21 @@ module Atmopshere
     extend ActiveSupport::Concern
 
     included do
-      every(1.minute, 'monitoring.templates') do
+      every(Atmosphere.monitoring.vmt, 'monitoring.templates') do
         action_on_actice_cses('templates monitoring',
                               Atmosphere::VmTemplateMonitoringWorker)
       end
 
-      every(30.seconds, 'monitoring.vms') do
+      every(Atmosphere.monitoring.vm, 'monitoring.vms') do
         action_on_actice_cses('vms monitoring',
                               Atmosphere::VmMonitoringWorker)
       end
 
-      every(Atmosphere.monitoring.query_interval.minutes, 'monitoring.load') do
+      every(Atmosphere.monitoring.load, 'monitoring.load') do
         Atmosphere::VmLoadMonitoringWorker.perform_async
       end
 
-      every(120.minutes, 'monitoring.flavors') do
+      every(Atmosphere.monitoring.flavor, 'monitoring.flavors') do
         Atmosphere::FlavorWorker.perform_async
       end
 

--- a/lib/atmosphere/clockwork.rb
+++ b/lib/atmosphere/clockwork.rb
@@ -3,21 +3,21 @@ module Atmopshere
     extend ActiveSupport::Concern
 
     included do
-      every(Atmosphere.monitoring.vmt, 'monitoring.templates') do
+      every(Atmosphere.monitoring.intervals.vmt, 'monitoring.templates') do
         action_on_actice_cses('templates monitoring',
                               Atmosphere::VmTemplateMonitoringWorker)
       end
 
-      every(Atmosphere.monitoring.vm, 'monitoring.vms') do
+      every(Atmosphere.monitoring.intervals.vm, 'monitoring.vms') do
         action_on_actice_cses('vms monitoring',
                               Atmosphere::VmMonitoringWorker)
       end
 
-      every(Atmosphere.monitoring.load, 'monitoring.load') do
+      every(Atmosphere.monitoring.intervals.load, 'monitoring.load') do
         Atmosphere::VmLoadMonitoringWorker.perform_async
       end
 
-      every(Atmosphere.monitoring.flavor, 'monitoring.flavors') do
+      every(Atmosphere.monitoring.intervals.flavor, 'monitoring.flavors') do
         Atmosphere::FlavorWorker.perform_async
       end
 

--- a/lib/generators/templates/atmosphere.rb
+++ b/lib/generators/templates/atmosphere.rb
@@ -50,6 +50,15 @@ Atmosphere.setup do |config|
   #
   # config.optimizer.max_appl_no = 5
 
+  # Cloud monitoring worker intervals for monitoring virtual machines (vm) and
+  # virtual machine templates (vmt), flavors (flavor) and updating information
+  # about virtual machines load (load)
+  #
+  # config.monitoring.vm = 30.seconds
+  # config.monitoring.vmt = 1.minute
+  # config.monitoring.flavor = 120.minutes
+  # config.monitoring.load = 5.minutes
+
   # Delay for registering new VM inside Atmosphere. This delay was introduced
   # bacause mointoring is an asynchronous process which sometine was triggered
   # durring the process of spawning new appliance. As a conclusion we had a

--- a/lib/generators/templates/atmosphere.rb
+++ b/lib/generators/templates/atmosphere.rb
@@ -54,10 +54,10 @@ Atmosphere.setup do |config|
   # virtual machine templates (vmt), flavors (flavor) and updating information
   # about virtual machines load (load)
   #
-  # config.monitoring.vm = 30.seconds
-  # config.monitoring.vmt = 1.minute
-  # config.monitoring.flavor = 120.minutes
-  # config.monitoring.load = 5.minutes
+  # config.monitoring.intervals.vm = 30.seconds
+  # config.monitoring.intervals.vmt = 1.minute
+  # config.monitoring.intervals.flavor = 120.minutes
+  # config.monitoring.intervals.load = 5.minutes
 
   # Delay for registering new VM inside Atmosphere. This delay was introduced
   # bacause mointoring is an asynchronous process which sometine was triggered


### PR DESCRIPTION
Rationale: ismop experiment, when we need to determine quite fast when VMs are up and running.