### PR TITLE
allow apps to use this engine's factories in rspecs

### DIFF
--- a/atmosphere.gemspec
+++ b/atmosphere.gemspec
@@ -28,7 +28,13 @@ Gem::Specification.new do |s|
   s.description = 'Atmosphere cloud platform'
   s.license     = 'MIT'
 
-  s.files = Dir['{app,config,db,lib,doc}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
+  s.files = Dir[
+                 '{app,config,db,lib,doc}/**/*',
+                 'spec/factories/**/*',
+                 'MIT-LICENSE',
+                 'Rakefile',
+                 'README.md'
+  ]
   s.test_files = Dir['spec/**/*']
 
   s.add_dependency 'rails', '~> 4.1.8'

--- a/lib/atmosphere/engine.rb
+++ b/lib/atmosphere/engine.rb
@@ -36,5 +36,13 @@ module Atmosphere
       g.assets false
       g.helper false
     end
+
+    initializer 'model_core.factories',
+                after: 'factory_girl.set_factory_paths' do
+      if defined?(FactoryGirl)
+        FactoryGirl.definition_file_paths <<
+          File.expand_path('../../../spec/factories', __FILE__)
+      end
+    end
   end
 end


### PR DESCRIPTION
I need to use factories from Atmo specs in PLGrid application. This fix is done according to this solution:

http://stackoverflow.com/questions/20261585/how-to-use-factorygirl-factories-from-an-engine