### PR TITLE
appliance types allowed params customization

### DIFF
--- a/app/controllers/atmosphere/api/v1/appliance_types_controller.rb
+++ b/app/controllers/atmosphere/api/v1/appliance_types_controller.rb
@@ -133,7 +133,14 @@ module Atmosphere
         end
 
         def appliance_type_params
-          params.require(:appliance_type).permit(:name, :description, :shared, :scalable, :visible_to, :author_id, :preference_cpu, :preference_memory, :preference_disk, :appliance_id)
+          allowed_params = [
+            :name, :description, :shared, :scalable,
+            :visible_to, :author_id, :preference_cpu,
+            :preference_memory, :preference_disk,
+            :appliance_id
+          ] + update_params_ext
+
+          params.require(:appliance_type).permit(allowed_params)
         end
 
         def pdp
@@ -143,6 +150,8 @@ module Atmosphere
         def model_class
           Atmosphere::ApplianceType
         end
+
+        include Atmosphere::Api::V1::ApplianceTypesControllerExt
       end
     end
   end

--- a/app/controllers/concerns/atmosphere/api/v1/appliance_types_controller_ext.rb
+++ b/app/controllers/concerns/atmosphere/api/v1/appliance_types_controller_ext.rb
@@ -1,0 +1,13 @@
+module Atmosphere
+  module Api
+    module V1
+      module ApplianceTypesControllerExt
+        extend ActiveSupport::Concern
+
+        def update_params_ext
+          []
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Changes required to fix [this spec](https://github.com/VPH-Share/atmosphere-vph/blob/master/spec/requests/atmosphere/appliance_types_spec.rb) in vph deployment.