### PR TITLE
Correct exception name

### DIFF
--- a/app/exceptions/atmosphere/unsuported_exception.rb
+++ b/app/exceptions/atmosphere/unsuported_exception.rb
@@ -1,3 +1,0 @@
-module Atmosphere
-  class UnsuportedException < Exception; end
-end

--- a/app/exceptions/atmosphere/unsupported_exception.rb
+++ b/app/exceptions/atmosphere/unsupported_exception.rb
@@ -1,0 +1,3 @@
+module Atmosphere
+  class UnsupportedException < Exception; end
+end

--- a/config/initializers/unify_fog_cloud_clients.rb
+++ b/config/initializers/unify_fog_cloud_clients.rb
@@ -91,11 +91,11 @@ class Fog::Compute::AWS::Server
   end
 
   def pause
-    raise Air::UnsuportedException, 'Amazon des not support pause action'
+    raise Atmosphere::UnsupportedException, 'Amazon des not support pause action'
   end
 
   def suspend
-    raise Air::UnsuportedException, 'Amazon des not support suspend action'
+    raise Atmosphere::UnsupportedException, 'Amazon des not support suspend action'
   end
 end
 


### PR DESCRIPTION
Before we started using Rails engine we had an exception Air::UnsuportedOperation. Please notice the typo in exception class name. After we switched to engine the module of this exception was renamed to Atmosphere, however the code that raises this exception was not refactored accordingly. This PR fixes this bug. 