### PR TITLE
setting version has precedence over setting AT

### DIFF
--- a/app/models/atmosphere/virtual_machine_template.rb
+++ b/app/models/atmosphere/virtual_machine_template.rb
@@ -62,7 +62,7 @@ module Atmosphere
 
     enumerize :state, in: ALLOWED_STATES
 
-    before_save :set_version, if: :appliance_type_id_changed?
+    before_save :set_version, if: :update_version?
     before_update :release_source_vm, if: :saved?
     after_update :destroy_source_vm, if: :saved?
     before_destroy :cant_destroy_non_managed_vmt
@@ -191,12 +191,12 @@ module Atmosphere
       compute_site.cloud_client
     end
 
+    def update_version?
+      !version_changed? && appliance_type_id_changed?
+    end
+
     def set_version
-      if new_record?
-        self.version ||= appliance_type.version + 1 if appliance_type
-      else
-        self.version = appliance_type.version + 1 if appliance_type
-      end
+      self.version = appliance_type.version + 1 if appliance_type
     end
   end
 end

--- a/app/services/atmosphere/cloud/vmt_updater.rb
+++ b/app/services/atmosphere/cloud/vmt_updater.rb
@@ -23,7 +23,7 @@ module Atmosphere
       vmt.state = image.status.downcase.to_sym
       if young?
         vmt.appliance_type ||= appliance_type
-        vmt.version ||= version
+        vmt.version = version if version
         unless vmt.managed_by_atmosphere
           vmt.managed_by_atmosphere = vmt.appliance_type != nil
         end

--- a/spec/models/atmosphere/virtual_machine_template_spec.rb
+++ b/spec/models/atmosphere/virtual_machine_template_spec.rb
@@ -314,5 +314,16 @@ describe Atmosphere::VirtualMachineTemplate do
 
       expect(vmt.version).to eq 1
     end
+
+    it 'setting version has precedence over assigning to AT' do
+      vmt = create(:virtual_machine_template, version: 15)
+      at = create(:appliance_type)
+
+      vmt.appliance_type = at
+      vmt.version = 3
+      vmt.save
+
+      expect(vmt.version).to eq 3
+    end
   end
 end


### PR DESCRIPTION
It solved the problem when VMT is migrated into Amazon. There it is not possible to register template and set its metadata as atomic operation. As a conclusion VMT was first discovered but not assigned to appliance type and version was not set. Next after metadata was added monitoring assigns this VMT into appliance type and set version into `appliance_type.version + 1`. This is obviously bug. This commit fixes this issue, by allowing to update version by the monitoring when VMT is young. What is more during "young" period if administrator changes source VMT version it will be populated into migrated VMT.

Fixes #112 and #113