### PR TITLE
Rackspace integration

### DIFF
--- a/app/models/atmosphere/compute_site.rb
+++ b/app/models/atmosphere/compute_site.rb
@@ -78,10 +78,13 @@ module Atmosphere
 
     validates :technology,
               presence: true,
-              inclusion: %w(openstack aws)
+              inclusion: %w(openstack aws rackspace)
 
     enumerize :site_type, in: [:public, :private], predicates: true
-    enumerize :technology, in: [:openstack, :aws], predicates: true
+
+    enumerize :technology,
+              in: [:openstack, :aws, :rackspace],
+              predicates: true
 
     scope :with_appliance_type, ->(appliance_type) do
       joins(virtual_machines: {appliances: :appliance_set})

--- a/app/models/atmosphere/user_key.rb
+++ b/app/models/atmosphere/user_key.rb
@@ -99,7 +99,8 @@ module Atmosphere
         # ignore key not found errors because it is possible that key was never imported to compute site
         begin
           cloud_client.delete_key_pair(id_at_site)
-        rescue Fog::Compute::OpenStack::NotFound
+        rescue Fog::Compute::OpenStack::NotFound,
+               Fog::Compute::RackspaceV2::NotFound
         end
         logger.info "Deleted key #{id_at_site} from #{cs.name}"
       end

--- a/app/services/atmosphere/vm_updater.rb
+++ b/app/services/atmosphere/vm_updater.rb
@@ -102,7 +102,13 @@ module Atmosphere
     end
 
     def vm_flavor
-      VirtualMachineFlavor.where(compute_site: vm.compute_site, id_at_site: server.flavor['id']).first
+      VirtualMachineFlavor.
+        where(compute_site: vm.compute_site,
+              id_at_site: flavor_id).first
+    end
+
+    def flavor_id
+      server.respond_to?(:flavor_id) ? server.flavor_id : server.flavor['id']
     end
 
     def error

--- a/app/workers/atmosphere/vm_tags_creator_worker.rb
+++ b/app/workers/atmosphere/vm_tags_creator_worker.rb
@@ -24,7 +24,7 @@ module Atmosphere
 
     def tag(vm, tags_map)
       cs = vm.compute_site
-      if cs.technology == 'openstack'
+      if ['openstack', 'rackspace'].include?(cs.technology)
         tag_vm_on_openstack(vm, cs.cloud_client, tags_map)
       else
         tag_vm_on_amazon(vm, cs.cloud_client, tags_map)

--- a/config/initializers/unify_rackspace.rb
+++ b/config/initializers/unify_rackspace.rb
@@ -1,0 +1,85 @@
+require 'fog/rackspace/models/compute_v2/image'
+require 'fog/rackspace/models/compute_v2/flavor'
+require 'fog/rackspace/models/compute_v2/server'
+
+module Fog
+  module Compute
+    class RackspaceV2
+      class Image
+        def architecture
+          'x86_64'
+        end
+
+        def tags
+          metadata.to_hash
+        end
+
+        def status
+          state
+        end
+      end
+
+      class Flavor
+        def supported_architectures
+          'x86_64'
+        end
+      end
+
+      class Server
+        def task_state
+          state_ext
+        end
+
+        def stop
+          raise Atmosphere::UnsupportedException,
+                'Rackspace des not support stop action'
+        end
+
+        def pause
+          raise Atmosphere::UnsupportedException,
+                'Rackspace des not support pause action'
+        end
+
+        def suspend
+          raise Atmosphere::UnsupportedException,
+                'Rackspace des not support suspend action'
+        end
+
+        def start
+          raise Atmosphere::UnsupportedException,
+                'Rackspace des not support start action'
+        end
+      end
+
+      class Real
+        def save_template(instance_id, tmpl_name)
+          resp = create_image(instance_id, tmpl_name)
+          if [200, 201, 202].include?(resp.status)
+            image_id(resp)
+          else
+            raise "Failed to save vm #{instance_id} as template"
+          end
+        end
+
+        def create_tags_for_vm(server_id, tags_map)
+          set_metadata('servers', server_id, tags_map)
+        end
+
+        def import_key_pair(name, public_key)
+          create_keypair(name, public_key: public_key)
+        end
+
+        def delete_key_pair(id_at_site)
+          delete_keypair(id_at_site)
+        end
+
+        private
+
+        def image_id(resp)
+          match = resp.headers['Location'].match(/.*\/(.*)\z/)
+          match && match[1]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
In the scope of this PR rackspace compute site integration will be implemented. To make it possible following actions need to be supported:

  * [x] Get flavors (`FlavorManager`)
  * [x] Get flavor data (`FlavorManager`)
  * [x] Get vms (`VmMonitoringWorker`)
  * [x] Get vm data (`VmUpdater`)
  * [x] Create tags for vm (`VmTagsCreator`)
  * [x] Get templates	 (`VmTemplateMonitoringWorker`)
  * [x] Destroy vm (`VirtualMachine`)
  * [x] Managing vm (`VirtualMachine`)
  * [x] Save template	(`VirtualMachineTemplate`)
  * [x] Destroy template (`VirtualMachineTemplate`)
  * [x] Create vm (`VmCreator`)
  * [x] Import key pair (`UserKey`)
  * [x] Delete key pair (`UserKey`)
  * [x] Get template data (`VmtUpdater`)