### PR TITLE
Use session and CSRF protection when no API token given

### DIFF
--- a/app/controllers/atmosphere/api/application_controller.rb
+++ b/app/controllers/atmosphere/api/application_controller.rb
@@ -2,7 +2,8 @@ module Atmosphere
   module Api
     class ApplicationController < ::ApplicationController
       include Atmosphere::Api::ApplicationControllerExt
-      protect_from_forgery with: :null_session
+      protect_from_forgery with: :null_session, if: :token_request?
+      protect_from_forgery with: :exception, unless: :token_request?
 
       check_authorization
 

--- a/app/controllers/concerns/atmosphere/api/application_controller_ext.rb
+++ b/app/controllers/concerns/atmosphere/api/application_controller_ext.rb
@@ -5,6 +5,10 @@ module Atmosphere
 
       def delegate_auth
       end
+
+      def token_request?
+        false
+      end
     end
   end
 end

--- a/spec/requests/atmosphere/api/use_session_when_no_api_token_spec.rb
+++ b/spec/requests/atmosphere/api/use_session_when_no_api_token_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe 'Use session when no api token' do
+  include ApiHelpers
+  include Warden::Test::Helpers
+
+  before { ActionController::Base.allow_forgery_protection = true }
+  after { ActionController::Base.allow_forgery_protection = false }
+
+  it 'use session when no token' do
+    login_user
+
+    get api('/users')
+
+    expect(response.status).to eq 200
+  end
+
+  it 'requires token when request other then GET' do
+    user = login_user
+    at = create(:appliance_type, author: user)
+
+    expect { delete api("/appliance_types/#{at.id}") }.
+      to raise_error(ActionController::InvalidAuthenticityToken)
+  end
+
+  def login_user
+    create(:user).tap { |user| login_as(user, scope: :user) }
+  end
+end


### PR DESCRIPTION
It is useful when Clew is embedded into Atmosphere home page. Than we don't need to pass any token only session cookie and valid CSRF token is needed.

CSRF token can be passed into Clew using following method `form_authenticity_token`.

To distinguish when token authentication should be used dedicated method is created in `Atmosphere::Api::ApplicationControllerExt` `token_request?`. It should return `true` when token is present in the request. It need to be overridden in every project with token support which uses Atmosphere.