### PR TITLE
renamed column name in appliance_types table

### DIFF
--- a/app/models/atmosphere/appliance_type.rb
+++ b/app/models/atmosphere/appliance_type.rb
@@ -27,7 +27,7 @@ module Atmosphere
       foreign_key: 'user_id'
 
     belongs_to :os_family,
-      class_name: 'Atmosphere::OSFamily',
+      class_name: 'Atmosphere::OSFamily'
 
     has_many :appliances,
       dependent: :destroy,

--- a/app/models/atmosphere/appliance_type.rb
+++ b/app/models/atmosphere/appliance_type.rb
@@ -28,7 +28,6 @@ module Atmosphere
 
     belongs_to :os_family,
       class_name: 'Atmosphere::OSFamily',
-      foreign_key: 'os_family_id'
 
     has_many :appliances,
       dependent: :destroy,

--- a/app/models/atmosphere/appliance_type.rb
+++ b/app/models/atmosphere/appliance_type.rb
@@ -28,7 +28,7 @@ module Atmosphere
 
     belongs_to :os_family,
       class_name: 'Atmosphere::OSFamily',
-      foreign_key: 'atmosphere_os_families_id'
+      foreign_key: 'os_family_id'
 
     has_many :appliances,
       dependent: :destroy,
@@ -186,7 +186,6 @@ module Atmosphere
     def self.appliance_type_attributes(appliance, overwrite)
       if appliance and appliance.dev_mode_property_set
         params = appliance.dev_mode_property_set.attributes
-        params['atmosphere_os_families_id'] = params.delete 'os_family_id'
         %w(id created_at updated_at appliance_id).each { |el| params.delete(el) }
       end
       params ||= {}

--- a/db/migrate/20150113100404_add_osfamilies.rb
+++ b/db/migrate/20150113100404_add_osfamilies.rb
@@ -16,11 +16,15 @@ class AddOsfamilies < ActiveRecord::Migration
       t.belongs_to :os_family
     end
 
-    add_reference :atmosphere_appliance_types, :atmosphere_os_families, index: true
+    add_reference :atmosphere_appliance_types, :os_family, index: true
 
     # Spawn two records and rewrite existing ATypes to bind to a specific os_family
     os_windows = Atmosphere::OSFamily.create(name: 'Windows')
     os_linux = Atmosphere::OSFamily.create(name: 'Linux')
+
+    # for some reason we need to force ApplianceType model class
+    # without it rake migrate:redo failed
+    Atmosphere::ApplianceType.reset_column_information
 
     # Rewrite all existing ATs to use the 'windows' OS (correct later as necessary)
 
@@ -51,7 +55,7 @@ class AddOsfamilies < ActiveRecord::Migration
       end
     end
 
-    remove_column :atmosphere_appliance_types, :atmosphere_os_families_id
+    remove_column :atmosphere_appliance_types, :os_family_id
 
     drop_table :atmosphere_flavor_os_families
     drop_table :atmosphere_os_families

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -71,22 +71,22 @@ ActiveRecord::Schema.define(version: 20150224171920) do
   add_index "atmosphere_appliance_sets", ["user_id"], name: "index_atmosphere_appliance_sets_on_user_id", using: :btree
 
   create_table "atmosphere_appliance_types", force: true do |t|
-    t.string   "name",                                        null: false
+    t.string   "name",                                null: false
     t.text     "description"
-    t.boolean  "shared",                    default: false,   null: false
-    t.boolean  "scalable",                  default: false,   null: false
-    t.string   "visible_to",                default: "owner", null: false
+    t.boolean  "shared",            default: false,   null: false
+    t.boolean  "scalable",          default: false,   null: false
+    t.string   "visible_to",        default: "owner", null: false
     t.float    "preference_cpu"
     t.integer  "preference_memory"
     t.integer  "preference_disk"
     t.integer  "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "atmosphere_os_families_id"
+    t.integer  "os_family_id"
   end
 
-  add_index "atmosphere_appliance_types", ["atmosphere_os_families_id"], name: "index_atmosphere_appliance_types_on_atmosphere_os_families_id", using: :btree
   add_index "atmosphere_appliance_types", ["name"], name: "index_atmosphere_appliance_types_on_name", unique: true, using: :btree
+  add_index "atmosphere_appliance_types", ["os_family_id"], name: "index_atmosphere_appliance_types_on_os_family_id", using: :btree
 
   create_table "atmosphere_appliances", force: true do |t|
     t.integer  "appliance_set_id",                                    null: false


### PR DESCRIPTION
https://github.com/dice-cyfronet/atmosphere/issues/120

It used to be atomsphere_os_famielies_id and the correct name os_family_id