### PR TITLE
Ignore second reboot conflict exception

### DIFF
--- a/app/models/atmosphere/virtual_machine.rb
+++ b/app/models/atmosphere/virtual_machine.rb
@@ -237,8 +237,8 @@ module Atmosphere
       errors.add :base, 'Virtual Machine is not managed by atmosphere' unless managed_by_atmosphere
     end
 
-    def cloud_action(aciton_name, sucess_state)
-      action_status = cloud_server.send(aciton_name)
+    def cloud_action(action_name, sucess_state)
+      action_status = cloud_server.send(action_name)
       change_state_on_success(action_status, sucess_state)
     end
 

--- a/app/models/atmosphere/virtual_machine.rb
+++ b/app/models/atmosphere/virtual_machine.rb
@@ -98,6 +98,8 @@ module Atmosphere
 
     def reboot
       cloud_action(:reboot, :reboot)
+    rescue Excon::Errors::Conflict
+      # ok reboot already in progress
     end
 
     def stop
@@ -235,21 +237,9 @@ module Atmosphere
       errors.add :base, 'Virtual Machine is not managed by atmosphere' unless managed_by_atmosphere
     end
 
-    def monitoring_client
-      Atmosphere.monitoring_client
-    end
-
-    def cloud_action(action_name, sucess_state)
-      action_status = cloud_server.send(action_name)
+    def cloud_action(aciton_name, sucess_state)
+      action_status = cloud_server.send(aciton_name)
       change_state_on_success(action_status, sucess_state)
-    end
-
-    def cloud_server
-      cloud_client.servers.get(id_at_site)
-    end
-
-    def cloud_client
-      @cloud_client ||= compute_site.cloud_client
     end
 
     def change_state_on_success(success, new_state)
@@ -259,6 +249,18 @@ module Atmosphere
       else
         false
       end
+    end
+
+    def monitoring_client
+      Atmosphere.monitoring_client
+    end
+
+    def cloud_server
+      cloud_client.servers.get(id_at_site)
+    end
+
+    def cloud_client
+      @cloud_client ||= compute_site.cloud_client
     end
   end
 end

--- a/app/models/atmosphere/virtual_machine.rb
+++ b/app/models/atmosphere/virtual_machine.rb
@@ -237,9 +237,9 @@ module Atmosphere
       errors.add :base, 'Virtual Machine is not managed by atmosphere' unless managed_by_atmosphere
     end
 
-    def cloud_action(action_name, sucess_state)
+    def cloud_action(action_name, success_state)
       action_status = cloud_server.send(action_name)
-      change_state_on_success(action_status, sucess_state)
+      change_state_on_success(action_status, success_state)
     end
 
     def change_state_on_success(success, new_state)

--- a/spec/models/atmosphere/virtual_machine_spec.rb
+++ b/spec/models/atmosphere/virtual_machine_spec.rb
@@ -370,6 +370,14 @@ describe Atmosphere::VirtualMachine do
       change_state_after_action(:start, 'active')
     end
 
+    it 'skip second vm restart', focus: true do
+      expect(server).
+        to receive(:reboot).
+        and_raise(Excon::Errors::Conflict.new('conflict'))
+
+      vm.send(:reboot)
+    end
+
     def invoke_cloud_action(action_name)
       expect(server).to receive(action_name)
 


### PR DESCRIPTION
We can ignore it since reboot is already in progress.

Fix #100