### PR TITLE
Fix removing VMT from AT using admin view

### DIFF
--- a/app/controllers/atmosphere/admin/virtual_machine_templates_controller.rb
+++ b/app/controllers/atmosphere/admin/virtual_machine_templates_controller.rb
@@ -36,7 +36,7 @@ class Atmosphere::Admin::VirtualMachineTemplatesController < Atmosphere::Admin::
   # PATCH/PUT /virtual_machine_templates/1
   def update
     if @virtual_machine_template.update(virtual_machine_template_params)
-      if Rails.application.routes.recognize_path(request.referrer)[:controller] == 'admin/appliance_types'
+      if Atmosphere::Engine.routes.recognize_path(request.referrer)[:controller] == 'atmosphere/admin/appliance_types'
         redirect_to request.referer
       else
         redirect_to admin_virtual_machine_template_url(@virtual_machine_template),


### PR DESCRIPTION
Since we moved Atmosphere into engine

```ruby
Rails.application.routes.recognize_path('host/admin/appliance_types')
```

is throwing

```
ActionController::RoutingError: No route matches "http://localhost:3000/admin/appliance_types/4
```

The fix is to use `Atmosphere::Engine` instead of `Rails` and change `admin/appliance_types` into `atmosphere/admin/appliance_types`.

Fix #91