### PR TITLE
Correct delete button title on AT admin view

### DIFF
--- a/app/views/atmosphere/admin/appliance_types/_view.html.haml
+++ b/app/views/atmosphere/admin/appliance_types/_view.html.haml
@@ -13,10 +13,10 @@
       = link_to admin_appliance_type_path(@appliance_type),
                 method: :delete,
                 class: 'btn btn-danger btn-xs',
-                title: t('yes_delete'),
+                title: t('delete'),
                 data: { confirm: t('are_you_sure_at') } do
         = icon 'trash-o'
-        = t('yes')
+        = t('delete')
 
   %h5
     - if @appliance_type.visible_to == 'owner'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,7 +21,6 @@
 
 en:
   yes: Yes
-  yes_delete: Yes, delete it.
   no: No
   index: Index
   admin: Admin


### PR DESCRIPTION
Buttons on admin AT show view, before:
![btns-before](https://cloud.githubusercontent.com/assets/1265430/7110420/1cef244c-e1b1-11e4-9aa2-1301050bb8c5.png)
after:
![btns-after](https://cloud.githubusercontent.com/assets/1265430/7110422/21501c12-e1b1-11e4-817e-2833d17f765f.png)

