### PR TITLE
Don't select development appliances on AT PMT change

### DIFF
--- a/spec/queries/atmosphere/appliances_affected_by_pmt_spec.rb
+++ b/spec/queries/atmosphere/appliances_affected_by_pmt_spec.rb
@@ -13,7 +13,9 @@ describe Atmosphere::AppliancesAffectedByPmt do
     let!(:appl1) { create(:appliance, appliance_type: at) }
 
     it 'finds affected appliances using appliance_type relation' do
+      # other appliances which should not be taken into account
       create(:appliance)
+      dev_appliance
 
       affected_appl = Atmosphere::AppliancesAffectedByPmt.new(pmt).find
 
@@ -30,15 +32,20 @@ describe Atmosphere::AppliancesAffectedByPmt do
 
   context 'in development mode' do
     it 'finds affected appliances using dev_mode_property_set relation' do
-      dev_as = create(:dev_appliance_set)
-      appl1 = create(:appliance, appliance_type: at, appliance_set: dev_as)
-      create(:appliance, appliance_type: at)
+      appl1 = dev_appliance
       dev_pmt = appl1.dev_mode_property_set.port_mapping_templates.first
+      # other appliances which should not be taken into account
+      create(:appliance, appliance_type: at)
 
       affected_appl = Atmosphere::AppliancesAffectedByPmt.new(dev_pmt).find
 
       expect(affected_appl.size).to eq 1
       expect(affected_appl.first).to eq appl1
     end
+  end
+
+  def dev_appliance
+    dev_as = create(:dev_appliance_set)
+    create(:appliance, appliance_type: at, appliance_set: dev_as)
   end
 end


### PR DESCRIPTION
When `PortMappingTemplate` is added, removed from `ApplianceType` only `Appliances` started in production should be affected. Development `Appliances` have PMT copied into `DevModePropertySet` and should not be modified.

Fix #135

/cc @dice-cyfronet/atmo-dev-team please take a look. If you have better way how to select only production appliances please let me know.