### PR TITLE
Services

### DIFF
--- a/app/models/atmosphere/appliance_type.rb
+++ b/app/models/atmosphere/appliance_type.rb
@@ -148,7 +148,7 @@ module Atmosphere
 
     def self.create_from(appliance, overwrite = {})
       at = ApplianceType.new appliance_type_attributes(appliance, overwrite)
-      PmtCopier.copy(appliance.dev_mode_property_set).each do |pmt|
+      PmtCopier.new(appliance.dev_mode_property_set).execute.each do |pmt|
         pmt.appliance_type = at
         at.port_mapping_templates << pmt
       end if appliance and appliance.dev_mode_property_set

--- a/app/models/atmosphere/appliance_type.rb
+++ b/app/models/atmosphere/appliance_type.rb
@@ -152,7 +152,7 @@ module Atmosphere
         pmt.appliance_type = at
         at.port_mapping_templates << pmt
       end if appliance and appliance.dev_mode_property_set
-      ActCopier.copy(appliance.appliance_type).each do |act|
+      ActCopier.new(appliance.appliance_type).execute.each do |act|
         act.appliance_type = at
         at.appliance_configuration_templates << act
       end if appliance

--- a/app/models/atmosphere/dev_mode_property_set.rb
+++ b/app/models/atmosphere/dev_mode_property_set.rb
@@ -73,7 +73,7 @@ module Atmosphere
 
       dev_mode_property_set = DevModePropertySet.new(attrs)
       dev_mode_property_set.port_mapping_templates =
-        PmtCopier.copy(appliance_type).each  do |pmt|
+        PmtCopier.new(appliance_type).execute.each  do |pmt|
           pmt.dev_mode_property_set = dev_mode_property_set
         end
 

--- a/app/models/atmosphere/dev_mode_property_set.rb
+++ b/app/models/atmosphere/dev_mode_property_set.rb
@@ -73,7 +73,7 @@ module Atmosphere
 
       dev_mode_property_set = DevModePropertySet.new(attrs)
       dev_mode_property_set.port_mapping_templates =
-        PmtCopier.new(appliance_type).execute.each  do |pmt|
+        PmtCopier.new(appliance_type).execute.each do |pmt|
           pmt.dev_mode_property_set = dev_mode_property_set
         end
 

--- a/app/services/atmosphere/act_copier.rb
+++ b/app/services/atmosphere/act_copier.rb
@@ -1,11 +1,21 @@
 module Atmosphere
   class ActCopier
-    def self.copy(at)
-      at.appliance_configuration_templates.collect do |act|
+    def initialize(appliance_type)
+      @appliance_type = appliance_type
+    end
+
+    def execute
+      create_copy if @appliance_type
+    end
+
+    private
+
+    def create_copy
+      @appliance_type.appliance_configuration_templates.collect do |act|
         copy = act.dup
         copy.appliance_type = nil
         copy
-      end if at
+      end
     end
   end
 end

--- a/app/services/atmosphere/act_copier.rb
+++ b/app/services/atmosphere/act_copier.rb
@@ -11,7 +11,7 @@ module Atmosphere
     private
 
     def create_copy
-      @appliance_type.appliance_configuration_templates.collect do |act|
+      @appliance_type.appliance_configuration_templates.map do |act|
         copy = act.dup
         copy.appliance_type = nil
         copy

--- a/app/services/atmosphere/appliance_vms_manager.rb
+++ b/app/services/atmosphere/appliance_vms_manager.rb
@@ -103,7 +103,7 @@ module Atmosphere
           user_data: appliance.user_data,
           user_key: appliance.user_key,
           nic: nic
-        ).spawn_vm!
+        ).execute
     end
 
     def add_vm(vm)

--- a/app/services/atmosphere/appliance_vms_manager.rb
+++ b/app/services/atmosphere/appliance_vms_manager.rb
@@ -10,7 +10,7 @@ module Atmosphere
       @appliance = appliance
       @updater = updater_class.new(appliance)
       @vm_creator_class = vm_creator_class
-      @tags_manager = tags_manager_class.new
+      @tags_manager_class = tags_manager_class
     end
 
     def reuse_vm!(vm)
@@ -114,7 +114,7 @@ module Atmosphere
     def appliance_satisfied(vm)
       appliance.state = :satisfied
       updater.update(new_vm: vm)
-      @tags_manager.create_tags_for_vm(vm)
+      @tags_manager_class.new(vm).execute
     end
 
     def bill

--- a/app/services/atmosphere/cloud/vm_creator.rb
+++ b/app/services/atmosphere/cloud/vm_creator.rb
@@ -9,7 +9,7 @@ module Atmosphere
       @nic = options[:nic]
     end
 
-    def spawn_vm!
+    def execute
       register_user_key!
 
       server_params = {

--- a/app/services/atmosphere/cloud/vm_tags_manager.rb
+++ b/app/services/atmosphere/cloud/vm_tags_manager.rb
@@ -1,10 +1,18 @@
 module Atmosphere
   class Cloud::VmTagsManager
-    def create_tags_for_vm(vm)
+    def initialize(vm)
+      @vm = vm
+    end
+
+    def execute
       users = User.with_vm(vm).collect{|u| u.login}.join(', ')
       VmTagsCreatorWorker.perform_async(vm.id,
         {'Name' => vm.name, 'Appliance type name' => vm.appliance_type.name, 'Users' => users}
       )
     end
+
+    private
+
+    attr_reader :vm
   end
 end

--- a/app/services/atmosphere/cloud/vmt_updater.rb
+++ b/app/services/atmosphere/cloud/vmt_updater.rb
@@ -6,7 +6,7 @@ module Atmosphere
       @all = options[:all]
     end
 
-    def update
+    def execute
       perform_update!
 
       vmt

--- a/app/services/atmosphere/pmt_copier.rb
+++ b/app/services/atmosphere/pmt_copier.rb
@@ -1,6 +1,10 @@
 module Atmosphere
   class PmtCopier
-    def self.copy(object_with_pmt)
+    def initialize(object_with_pmt)
+      @object_with_pmt = object_with_pmt
+    end
+
+    def execute
       object_with_pmt.port_mapping_templates.collect do |pmt|
         copy = pmt.dup
         copy.appliance_type = nil
@@ -11,5 +15,9 @@ module Atmosphere
         copy
       end if object_with_pmt
     end
+
+    private
+
+    attr_reader :object_with_pmt
   end
 end

--- a/app/services/atmosphere/vm_updater.rb
+++ b/app/services/atmosphere/vm_updater.rb
@@ -6,7 +6,7 @@ module Atmosphere
       @updater_class = updater_class
     end
 
-    def update
+    def execute
       perform_update! if old_enough?
 
       vm

--- a/app/services/atmosphere/vmt_migrator.rb
+++ b/app/services/atmosphere/vmt_migrator.rb
@@ -10,6 +10,18 @@ module Atmosphere
       @destination_compute_site = destination_compute_site
     end
 
+    def execute
+      if @source_compute_site.technology == 'openstack'
+        migrator_class = select_migrator_class
+
+        if migrator_class
+          enqueue_job migrator_class
+        end
+      end
+    end
+
+    private
+
     def select_migrator_class
       case @destination_compute_site.technology
       when 'aws'
@@ -25,16 +37,6 @@ module Atmosphere
       'class' => migrator_class,
       'args' => [@virtual_machine_template.id_at_site,
                  @destination_compute_site.site_id])
-    end
-
-    def execute
-      if @source_compute_site.technology == 'openstack'
-        migrator_class = select_migrator_class
-
-        if migrator_class
-          enqueue_job migrator_class
-        end
-      end
     end
   end
 end

--- a/app/workers/atmosphere/vm_monitoring_worker.rb
+++ b/app/workers/atmosphere/vm_monitoring_worker.rb
@@ -30,7 +30,7 @@ module Atmosphere
       logger.debug { "#{jid}: updating information about VMs" }
       all_site_vms = site.virtual_machines.to_a
       servers.each do |server|
-        updated_vm = vm_updater_class.new(site, server).update
+        updated_vm = vm_updater_class.new(site, server).execute
         all_site_vms.delete updated_vm
       end
 

--- a/app/workers/atmosphere/vm_template_monitoring_worker.rb
+++ b/app/workers/atmosphere/vm_template_monitoring_worker.rb
@@ -34,7 +34,7 @@ module Atmosphere
       logger.debug { "#{jid}: updating VMTs" }
       all_site_templates = site.virtual_machine_templates.to_a
       images.each do |image|
-        updated_vmt = Cloud::VmtUpdater.new(site, image).update
+        updated_vmt = Cloud::VmtUpdater.new(site, image).execute
 
         all_site_templates.delete(updated_vmt)
       end

--- a/spec/services/atmosphere/appliance_vms_manager_spec.rb
+++ b/spec/services/atmosphere/appliance_vms_manager_spec.rb
@@ -102,7 +102,10 @@ describe Atmosphere::ApplianceVmsManager do
     let(:updater) { double('updater', update: true) }
     let(:updater_class) { double('updater class', new: updater) }
 
-    let(:vm_creator) { double('vm creator', :spawn_vm! => 'server_id') }
+    let(:vm_creator) do
+      instance_double(Atmosphere::Cloud::VmCreator,
+                      execute: 'server_id')
+    end
     let(:vm_creator_class) { double('vm creator class') }
 
     let(:tmpl) { create(:virtual_machine_template) }
@@ -202,7 +205,7 @@ describe Atmosphere::ApplianceVmsManager do
 
   context 'scaling'  do
     let(:appl) { build(:appliance) }
-    let(:vm_creator_class) { double('vm creator class') }
+    let(:vm_creator_class) { instance_double('vm creator class') }
 
     subject do
       Atmosphere::ApplianceVmsManager.
@@ -224,14 +227,14 @@ describe Atmosphere::ApplianceVmsManager do
       end
 
       def expect_vm_started(desc, vm_id_at_site)
-        first_creator = instance_double('Cloud::VmCreator')
+        first_creator = instance_double(Atmosphere::Cloud::VmCreator)
         allow(vm_creator_class).
           to receive(:new).
           with(desc[:template],
                hash_including(flavor: desc[:flavor], name: desc[:name])).
           and_return(first_creator)
 
-        expect(first_creator).to receive(:spawn_vm!).and_return(vm_id_at_site)
+        expect(first_creator).to receive(:execute).and_return(vm_id_at_site)
       end
 
       def vmt_desc(name)

--- a/spec/services/atmosphere/cloud/vm_creator_spec.rb
+++ b/spec/services/atmosphere/cloud/vm_creator_spec.rb
@@ -23,7 +23,7 @@ describe Atmosphere::Cloud::VmCreator do
 
   it 'creates VM' do
     allow(servers_cloud_client).to receive(:create).and_return(server)
-    vm_id_at_site = Atmosphere::Cloud::VmCreator.new(vmt).spawn_vm!
+    vm_id_at_site = Atmosphere::Cloud::VmCreator.new(vmt).execute
 
     expect(vm_id_at_site).to eq server_id
   end
@@ -34,7 +34,7 @@ describe Atmosphere::Cloud::VmCreator do
       expect(params[:image_id]).to eq vmt.id_at_site
     end.and_return(server)
 
-    Atmosphere::Cloud::VmCreator.new(vmt).spawn_vm!
+    Atmosphere::Cloud::VmCreator.new(vmt).execute
   end
 
   it 'creates VM with default flavor' do
@@ -43,7 +43,7 @@ describe Atmosphere::Cloud::VmCreator do
       expect(params[:flavor_id]).to eq default_flavor.id_at_site
     end.and_return(server)
 
-    Atmosphere::Cloud::VmCreator.new(vmt).spawn_vm!
+    Atmosphere::Cloud::VmCreator.new(vmt).execute
   end
 
   it 'creates VM with default name' do
@@ -51,7 +51,7 @@ describe Atmosphere::Cloud::VmCreator do
       expect(params[:name]).to eq vmt.name
     end.and_return(server)
 
-    Atmosphere::Cloud::VmCreator.new(vmt).spawn_vm!
+    Atmosphere::Cloud::VmCreator.new(vmt).execute
   end
 
   it 'creates VM with custom name' do
@@ -59,7 +59,7 @@ describe Atmosphere::Cloud::VmCreator do
       expect(params[:name]).to eq 'custom name'
     end.and_return(server)
 
-    Atmosphere::Cloud::VmCreator.new(vmt, name: 'custom name').spawn_vm!
+    Atmosphere::Cloud::VmCreator.new(vmt, name: 'custom name').execute
   end
 
   it 'creates VM with user data' do
@@ -67,7 +67,7 @@ describe Atmosphere::Cloud::VmCreator do
       expect(params[:user_data]).to eq 'my user data'
     end.and_return(server)
 
-    Atmosphere::Cloud::VmCreator.new(vmt, user_data: 'my user data').spawn_vm!
+    Atmosphere::Cloud::VmCreator.new(vmt, user_data: 'my user data').execute
   end
 
   it 'creates VM without user data when it is empty' do
@@ -75,7 +75,7 @@ describe Atmosphere::Cloud::VmCreator do
       expect(params).to_not include :user_data
     end.and_return(server)
 
-    Atmosphere::Cloud::VmCreator.new(vmt, user_data: nil).spawn_vm!
+    Atmosphere::Cloud::VmCreator.new(vmt, user_data: nil).execute
   end
 
   it 'creates VM with user key' do
@@ -85,7 +85,7 @@ describe Atmosphere::Cloud::VmCreator do
       expect(params[:key_name]).to eq 'my_key_name'
     end.and_return(server)
 
-    Atmosphere::Cloud::VmCreator.new(vmt, user_key: user_key).spawn_vm!
+    Atmosphere::Cloud::VmCreator.new(vmt, user_key: user_key).execute
   end
 
   context 'amazon' do
@@ -100,7 +100,7 @@ describe Atmosphere::Cloud::VmCreator do
         expect(params[:groups]).to include 'mniec_permit_all'
       end.and_return(server)
 
-      Atmosphere::Cloud::VmCreator.new(vmt).spawn_vm!
+      Atmosphere::Cloud::VmCreator.new(vmt).execute
     end
   end
 end

--- a/spec/services/atmosphere/cloud/vm_tags_manager_spec.rb
+++ b/spec/services/atmosphere/cloud/vm_tags_manager_spec.rb
@@ -21,6 +21,6 @@ describe Atmosphere::Cloud::VmTagsManager do
         expect(hsh['Users'].split(', ')).to include 'user1', 'user2'
       end
 
-    subject.create_tags_for_vm(vm)
+    described_class.new(vm).execute
   end
 end

--- a/spec/services/atmosphere/cloud/vmt_updater_spec.rb
+++ b/spec/services/atmosphere/cloud/vmt_updater_spec.rb
@@ -9,7 +9,7 @@ describe Atmosphere::Cloud::VmtUpdater do
       source_cs.site_id, source_vmt.id_at_site)
     updater = Atmosphere::Cloud::VmtUpdater.new(target_cs, image)
 
-    updater.update
+    updater.execute
     target_vmt = Atmosphere::VirtualMachineTemplate.find_by(id_at_site: 'target_vmt_id')
 
     expect(target_vmt.appliance_type).to eq at
@@ -31,7 +31,7 @@ describe Atmosphere::Cloud::VmtUpdater do
     })
     updater = Atmosphere::Cloud::VmtUpdater.new(target_cs, image)
 
-    updater.update
+    updater.execute
     target_vmt = Atmosphere::VirtualMachineTemplate.find_by(id_at_site: 'ami-123')
 
     expect(target_vmt.appliance_type).to eq at
@@ -49,7 +49,7 @@ describe Atmosphere::Cloud::VmtUpdater do
     source_vmt.version = 13
     source_vmt.save
 
-    updater.update
+    updater.execute
     target_vmt = Atmosphere::VirtualMachineTemplate.
                   find_by(id_at_site: 'target_vmt_id')
 
@@ -67,7 +67,7 @@ describe Atmosphere::Cloud::VmtUpdater do
                         id_at_site: 'target_vmt_id')
     updater = Atmosphere::Cloud::VmtUpdater.new(target_cs, image)
 
-    updater.update
+    updater.execute
     target_vmt.reload
 
     expect(target_vmt.version).to eq source_vmt.version
@@ -85,7 +85,7 @@ describe Atmosphere::Cloud::VmtUpdater do
       id_at_site: 'target_vmt_id',
       created_at: (Atmosphere.vmt_at_relation_update_period + 1).hours.ago)
 
-    updater.update
+    updater.execute
     target_vmt = Atmosphere::VirtualMachineTemplate.find_by(id_at_site: 'target_vmt_id')
 
     expect(target_vmt.appliance_type).to be_nil
@@ -98,7 +98,7 @@ describe Atmosphere::Cloud::VmtUpdater do
       source_cs.site_id, 'does_not_exist')
     updater = Atmosphere::Cloud::VmtUpdater.new(target_cs, image)
 
-    updater.update
+    updater.execute
     target_vmt = Atmosphere::VirtualMachineTemplate.find_by(id_at_site: 'target_vmt_id')
 
     expect(target_vmt.appliance_type).to be_nil
@@ -110,7 +110,7 @@ describe Atmosphere::Cloud::VmtUpdater do
       'does_not_exist', 'does_not_exist')
     updater = Atmosphere::Cloud::VmtUpdater.new(target_cs, image)
 
-    updater.update
+    updater.execute
     target_vmt = Atmosphere::VirtualMachineTemplate.find_by(id_at_site: 'target_vmt_id')
 
     expect(target_vmt.appliance_type).to be_nil
@@ -124,7 +124,7 @@ describe Atmosphere::Cloud::VmtUpdater do
     expect(Atmosphere::Cloud::RemoveOlderVmtWorker).
       to receive(:perform_async)
 
-    updater.update
+    updater.execute
   end
 
   it 'does not remove old VMT when old state is ACTIVE' do
@@ -139,7 +139,7 @@ describe Atmosphere::Cloud::VmtUpdater do
     expect(Atmosphere::Cloud::RemoveOlderVmtWorker).
       to_not receive(:perform_async)
 
-    updater.update
+    updater.execute
   end
 
   it 'does not remove old VMT when new status is different than ACTIVE' do
@@ -151,7 +151,7 @@ describe Atmosphere::Cloud::VmtUpdater do
     expect(Atmosphere::Cloud::RemoveOlderVmtWorker).
       to_not receive(:perform_async)
 
-    updater.update
+    updater.execute
   end
 
   def open_stack_image(image_id, source_cs, source_uuid)

--- a/spec/services/atmosphere/vm_updater_spec.rb
+++ b/spec/services/atmosphere/vm_updater_spec.rb
@@ -33,7 +33,7 @@ describe Atmosphere::VmUpdater do
       subject { Atmosphere::VmUpdater.new(cs, server, updater_class) }
 
       it 'sets "saving" state' do
-        vm = subject.update
+        vm = subject.execute
         expect(vm.state).to eq 'saving'
       end
     end
@@ -57,7 +57,7 @@ describe Atmosphere::VmUpdater do
       subject { Atmosphere::VmUpdater.new(cs, server, updater_class) }
 
       it 'sets "saving" state' do
-        vm = subject.update
+        vm = subject.execute
         expect(vm.state).to eq 'saving'
       end
     end
@@ -83,7 +83,7 @@ describe Atmosphere::VmUpdater do
         expect(updater_class).to receive(:new).with(appl2).and_return(appl_updater)
         expect(appl_updater).to receive(:update).twice
 
-        subject.update
+        subject.execute
       end
 
       it 'does not invoke updater when ip not changed' do
@@ -94,7 +94,7 @@ describe Atmosphere::VmUpdater do
 
         expect(updater).to_not receive(:update)
 
-        subject.update
+        subject.execute
       end
 
       it 'does not invoke updater when no vm appliances' do
@@ -102,7 +102,7 @@ describe Atmosphere::VmUpdater do
 
         expect(updater).to_not receive(:update)
 
-        subject.update
+        subject.execute
       end
 
       it 'invokes updater when VM with IP changed state to active' do
@@ -116,7 +116,7 @@ describe Atmosphere::VmUpdater do
 
         expect(updater).to receive(:update)
 
-        subject.update
+        subject.execute
       end
 
       it 'does not invoke updter when VM without IP state changed to active' do
@@ -130,7 +130,7 @@ describe Atmosphere::VmUpdater do
 
         expect(updater).not_to receive(:update)
 
-        Atmosphere::VmUpdater.new(cs, server, updater_class).update
+        Atmosphere::VmUpdater.new(cs, server, updater_class).execute
       end
     end
 
@@ -159,7 +159,7 @@ describe Atmosphere::VmUpdater do
           to receive(:update).
           once
 
-        subject.update
+        subject.execute
       end
 
       it 'does not invoke update when state changed to !active' do
@@ -169,7 +169,7 @@ describe Atmosphere::VmUpdater do
 
         expect(updater).to_not receive(:update)
 
-        subject.update
+        subject.execute
       end
 
       it 'does not invoke updater even when ip changed' do
@@ -180,7 +180,7 @@ describe Atmosphere::VmUpdater do
 
         expect(updater).to_not receive(:update)
 
-        subject.update
+        subject.execute
       end
     end
   end
@@ -194,12 +194,12 @@ describe Atmosphere::VmUpdater do
     context 'and VM does not exist' do
       it 'creates missing VM' do
         expect {
-          subject.update
+          subject.execute
         }.to change { Atmosphere::VirtualMachine.count }.by(1)
       end
 
       it 'sets VMs details' do
-        subject.update
+        subject.execute
 
         expect(updated_vm).to vm_fog_data_equals(server, vmt)
       end
@@ -218,19 +218,19 @@ describe Atmosphere::VmUpdater do
 
       it 'reuses existing VM' do
         expect {
-          subject.update
+          subject.execute
         }.to change { Atmosphere::VirtualMachine.count }.by(0)
       end
 
       it 'updates VMs details' do
-        subject.update
+        subject.execute
 
         expect(updated_vm).to vm_fog_data_equals(server, vmt)
       end
     end
 
     it 'sets IP address' do
-      subject.update
+      subject.execute
 
       expect(updated_vm.ip).to eq '10.100.1.2'
     end
@@ -240,7 +240,7 @@ describe Atmosphere::VmUpdater do
     let(:server) { server_double_with_priv_ip }
 
     it 'sets private VM ip' do
-      subject.update
+      subject.execute
 
       expect(updated_vm.ip).to eq '10.100.2.3'
     end
@@ -254,7 +254,7 @@ describe Atmosphere::VmUpdater do
     end
 
     it 'sets default VM name' do
-      subject.update
+      subject.execute
 
       expect(updated_vm.name).to eq "[unnamed]"
     end
@@ -267,7 +267,7 @@ describe Atmosphere::VmUpdater do
     end
 
     it 'sets IP address' do
-      subject.update
+      subject.execute
 
       expect(updated_vm.ip).to eq '10.100.1.2'
     end
@@ -280,7 +280,7 @@ describe Atmosphere::VmUpdater do
     end
 
     it 'does not set IP address' do
-      subject.update
+      subject.execute
 
       expect(updated_vm.ip).to be_nil
     end
@@ -291,7 +291,7 @@ describe Atmosphere::VmUpdater do
 
     it 'does not update VM data' do
       expect {
-        subject.update
+        subject.execute
       }.to change { Atmosphere::VirtualMachine.count }.by(0)
     end
   end
@@ -315,7 +315,7 @@ describe Atmosphere::VmUpdater do
                   created_at: old_vm_creation_time)
       allow(server).to receive(:updated).and_return(vm_update_at)
 
-      Atmosphere::VmUpdater.new(cs, server, updater_class).update
+      Atmosphere::VmUpdater.new(cs, server, updater_class).execute
       vm.reload
 
       expect(vm.ip).to eq '1.2.3.4'
@@ -330,7 +330,7 @@ describe Atmosphere::VmUpdater do
                   created_at: old_vm_creation_time)
       allow(server).to receive(:updated).and_return(vm_update_at + 1)
 
-      Atmosphere::VmUpdater.new(cs, server, updater_class).update
+      Atmosphere::VmUpdater.new(cs, server, updater_class).execute
       vm.reload
 
       expect(vm.ip).to eq '1.2.3.4'
@@ -344,7 +344,7 @@ describe Atmosphere::VmUpdater do
                   compute_site: cs)
       allow(server).to receive(:updated).and_return(vm_update_at - 1)
 
-      Atmosphere::VmUpdater.new(cs, server, updater_class).update
+      Atmosphere::VmUpdater.new(cs, server, updater_class).execute
       vm.reload
 
       expect(vm.ip).to be_nil

--- a/spec/workers/atmosphere/vm_monitoring_worker_spec.rb
+++ b/spec/workers/atmosphere/vm_monitoring_worker_spec.rb
@@ -35,9 +35,9 @@ describe Atmosphere::VmMonitoringWorker do
         allow(cloud_client).to receive(:servers).and_return(['1', '2'])
         allow(cs).to receive(:virtual_machines).and_return([])
 
-        expect(updater1).to receive(:update).and_return('1')
+        expect(updater1).to receive(:execute).and_return('1')
         expect(vm_updater_class).to receive(:new).with(cs, '1').and_return(updater1)
-        expect(updater2).to receive(:update).and_return('2')
+        expect(updater2).to receive(:execute).and_return('2')
         expect(vm_updater_class).to receive(:new).with(cs, '2').and_return(updater2)
 
         subject.perform(1)


### PR DESCRIPTION
In the scope of this PR I'm planning to unify how services looks like in atmosphere. Basically following conditions should be met:

  * Service is doing only **one** thing and has only **one** public method `execute`
  * All needed parameters are passed using constructor parameters

So as a conclusion every atmosphere service will have following structure:

```ruby
class MyService
  def initialize(set, of, parameters)
    ...
  end

  def execute
    # do actual job
  end
end
```

List of class we currently have in `app/services' directory:
  * [x] cloud/vm_creator
  * [x] cloud/vm_tags_manager
  * [x] cloud/vmt_updater
  * [ ] monitoring/influxdb_metrics_store
  * [ ] monitoring/null_client
  * [ ] monitoring/null_metrics_store
  * [ ] monitoring/zabix_client
  * [ ] proxy/appliance_proxy_updater
  * [ ] proxy/compute_site_appliances_updater
  * [ ] proxy/compute_site_url_updater
  * [ ] proxy/url_generator
  * [x] act_copier
  * [ ] affected_appliance_aware_manager
  * [ ] billing_service
  * [ ] dnat_wrangler
  * [ ] flavor_manager
  * [ ] optimizer
  * [x] pmt_copier
  * [x] save_as_service
  * [ ] vm_destroyer
  * [x] vm_updater
  * [x] vmt_migrator