### PR TITLE
Use Atmosphere engine migrations in project using Atmosphere

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ To upgrade to latest master run following commands:
 # update atmosphere gem
 bundle update atmosphere
 
-# install new migrations
-rake atmosphere:install:migrations
+# apply new migrations
+rake db:migrate
 ```
 
 ## Contributing

--- a/lib/atmosphere/engine.rb
+++ b/lib/atmosphere/engine.rb
@@ -39,6 +39,14 @@ module Atmosphere
       g.helper false
     end
 
+    initializer :append_migrations do |app|
+      unless app.root.to_s.match root.to_s
+        config.paths['db/migrate'].expanded.each do |expanded_path|
+          app.config.paths['db/migrate'] << expanded_path
+        end
+      end
+    end
+
     if Rails.env.test?
       initializer 'model_core.factories',
                   after: 'factory_girl.set_factory_paths' do

--- a/lib/generators/atmosphere/install_generator.rb
+++ b/lib/generators/atmosphere/install_generator.rb
@@ -20,10 +20,6 @@ module Atmosphere
         route 'mount Atmosphere::Engine => "/"'
       end
 
-      def copy_migrations
-        rake 'atmosphere:install:migrations'
-      end
-
       def show_readme
         readme 'README' if behavior == :invoke
       end


### PR DESCRIPTION
See http://pivotallabs.com/leave-your-migrations-in-your-rails-engines for details.

For vph, plgrid and exp dedicated sql script which removes copied atmo migrations numbers from schema table and add origin numbers need to be created and performed before pushing this change.

This change requires dependent projects to remove old migration timestamps from DB and add original atmosphere migration timestamps. 

Below is the status of dependent projects preparation for this change:
  * [x] https://github.com/VPH-Share/atmosphere-vph/pull/10 vph (responsible @mkasztelnik)
  * [x] https://gitlab.dev.cyfronet.pl/atmosphere/plgrid/merge_requests/26 plgrid (responsible @tbartynski, @nowakowski)
  * [x] https://github.com/ismop/exp/pull/1 exp (responsible @mkasztelnik)

@dice-cyfronet/atmo-dev-team please take a look