### PR TITLE
Clean nic provider spec

### DIFF
--- a/spec/lib/atmosphere_spec.rb
+++ b/spec/lib/atmosphere_spec.rb
@@ -85,26 +85,20 @@ describe Atmosphere do
       end
 
       it 'creates provider of appropriate class if config is empty' do
-        PROVIDER_CONF_STR = ''
-        PROVIDER_CONF = {}
-        cs.nic_provider_config = PROVIDER_CONF_STR
-        expect(DummyNicProvider).to receive(:new).with PROVIDER_CONF
+        cs.nic_provider_config = ''
+        expect(DummyNicProvider).to receive(:new).with({})
         Atmosphere.nic_provider(cs)
       end
 
       it 'creates provider of appropriate class if config is empty' do
-        PROVIDER_CONF_STR = nil
-        PROVIDER_CONF = {}
-        cs.nic_provider_config = PROVIDER_CONF_STR
-        expect(DummyNicProvider).to receive(:new).with PROVIDER_CONF
+        cs.nic_provider_config = nil
+        expect(DummyNicProvider).to receive(:new).with({})
         Atmosphere.nic_provider(cs)
       end
 
       it 'creates provider with compute site specific configuration' do
-        PROVIDER_CONF_STR = '{}'
-        PROVIDER_CONF = JSON.parse(PROVIDER_CONF_STR).symbolize_keys
-        cs.nic_provider_config = PROVIDER_CONF_STR
-        expect(DummyNicProvider).to receive(:new).with PROVIDER_CONF
+        cs.nic_provider_config = '{"key": "val"}'
+        expect(DummyNicProvider).to receive(:new).with(key: 'val')
         Atmosphere.nic_provider(cs)
       end
     end


### PR DESCRIPTION
Fix:

```
/home/travis/build/dice-cyfronet/atmosphere/spec/lib/atmosphere_spec.rb:96: warning: already initialized constant PROVIDER_CONF_STR
/home/travis/build/dice-cyfronet/atmosphere/spec/lib/atmosphere_spec.rb:88: warning: previous definition of PROVIDER_CONF_STR was here
/home/travis/build/dice-cyfronet/atmosphere/spec/lib/atmosphere_spec.rb:97: warning: already initialized constant PROVIDER_CONF
/home/travis/build/dice-cyfronet/atmosphere/spec/lib/atmosphere_spec.rb:89: warning: previous definition of PROVIDER_CONF was here
./home/travis/build/dice-cyfronet/atmosphere/spec/lib/atmosphere_spec.rb:104: warning: already initialized constant PROVIDER_CONF_STR
/home/travis/build/dice-cyfronet/atmosphere/spec/lib/atmosphere_spec.rb:96: warning: previous definition of PROVIDER_CONF_STR was here
/home/travis/build/dice-cyfronet/atmosphere/spec/lib/atmosphere_spec.rb:105: warning: already initialized constant PROVIDER_CONF
/home/travis/build/dice-cyfronet/atmosphere/spec/lib/atmosphere_spec.rb:97: warning: previous definition of PROVIDER_CONF was here
```

@dice-cyfronet/atmo-dev-team please take a look