### PR TITLE
VM in saving state when task state is image_pending_upload

### DIFF
--- a/app/services/atmosphere/vm_updater.rb
+++ b/app/services/atmosphere/vm_updater.rb
@@ -75,8 +75,16 @@ module Atmosphere
     end
 
     def map_saving_state(vm, key)
-      (:saving if vm.saved_templates.count > 0) ||
-        ({image_snapshot: :saving}[key.to_sym] if key)
+      :saving if saving_state?(vm, key)
+    end
+
+    def saving_state?(vm, key)
+      vm.saved_templates.count > 0 ||
+        saving_task_states.include?(key && key.to_sym)
+    end
+
+    def saving_task_states
+      [:image_snapshot, :image_pending_upload]
     end
 
     def vm

--- a/spec/services/atmosphere/vm_updater_spec.rb
+++ b/spec/services/atmosphere/vm_updater_spec.rb
@@ -23,19 +23,23 @@ describe Atmosphere::VmUpdater do
   subject { Atmosphere::VmUpdater.new(cs, server, updater_class) }
 
   describe 'VM states' do
-    context "when task state equals to image_snapshot" do
-      let(:server) do
-        server_double(state: 'active',
-                      task_state: 'image_snapshot',
-                      flavor: {'id' => "1"})
-      end
+    it 'is saving when task state equals to image_snapshot' do
+      saving_when_task_state('image_snapshot')
+    end
 
-      subject { Atmosphere::VmUpdater.new(cs, server, updater_class) }
+    it 'is saving when task state equals to image_pending_upload' do
+      saving_when_task_state('image_pending_upload')
+    end
 
-      it 'sets "saving" state' do
-        vm = subject.update
-        expect(vm.state).to eq 'saving'
-      end
+    def saving_when_task_state(state)
+      server = server_double(state: 'active',
+                             task_state: state,
+                             flavor: { 'id' => '1' })
+      updater = Atmosphere::VmUpdater.new(cs, server, updater_class)
+
+      vm = updater.update
+
+      expect(vm.state).to eq 'saving'
     end
 
     context 'when relation to saved_templates is not empty' do


### PR DESCRIPTION
This is a fix for: https://redmine.dev.cyfronet.pl/issues/3329. It solves following problem:

  * VM is in state active
  * Save button is clicked as a result new template should be created and state is changed into saving
  * We are canceling appliance saving process after e.g. 10s - open stack correctly removes template connected with deleted AT
  * As a result state of the appliance changes from "saving" into "active" right now. In the nova VM state is set to "active" but "task_state" is set to "image_pending_upload" - openstack does not cancel this operation for some reason. 
  * Now if we will try to save appliance once again Atmosphere throws error.