### PR TITLE
Turn off turbolinks for clew views

### DIFF
--- a/app/views/layouts/atmosphere/_navbar.html.haml
+++ b/app/views/layouts/atmosphere/_navbar.html.haml
@@ -1,6 +1,6 @@
 %header.navbar.navbar-fixed-top.navbar-default
   .container
-    = link_to t('code_name'), root_path, class: 'navbar-brand'
+    = link_to t('code_name'), root_path, class: 'navbar-brand', 'data-no-turbolink' => true
 
     %ul.nav.navbar-nav
       - if current_user.has_role? :admin

--- a/app/views/layouts/atmosphere/application.html.haml
+++ b/app/views/layouts/atmosphere/application.html.haml
@@ -2,7 +2,7 @@
 %html{ lang: 'en'}
   = render 'layouts/atmosphere/head'
   %body
-    #wrap
+    #wrap{"data-no-turbolink" => controller.controller_name == 'home'}
       .proper-content
         = render 'layouts/atmosphere/flash'
         = render 'layouts/atmosphere/navbar'


### PR DESCRIPTION
GWT is not compatible with turbolinks, that is why it need to be turned off for `home#index` view.

@dice-cyfronet/atmo-dev-team please take a look