### PR TITLE
VMF model equipped with two new callbacks

### DIFF
--- a/app/models/atmosphere/virtual_machine_flavor.rb
+++ b/app/models/atmosphere/virtual_machine_flavor.rb
@@ -25,7 +25,8 @@ module Atmosphere
       class_name: 'Atmosphere::ComputeSite'
 
     has_many :virtual_machines,
-      class_name: 'Atmosphere::VirtualMachine'
+      class_name: 'Atmosphere::VirtualMachine',
+      dependent: :restrict_with_error
 
     has_many :os_families,
       through: :flavor_os_families,
@@ -34,7 +35,8 @@ module Atmosphere
     has_many :flavor_os_families,
       inverse_of: :virtual_machine_flavor,
       class_name: 'Atmosphere::FlavorOSFamily',
-      autosave: true
+      autosave: true,
+      dependent: :destroy
 
     validates :flavor_name,
               presence: true

--- a/spec/models/atmosphere/virtual_machine_flavor_spec.rb
+++ b/spec/models/atmosphere/virtual_machine_flavor_spec.rb
@@ -163,5 +163,27 @@ describe Atmosphere::VirtualMachineFlavor do
           to change{ Atmosphere::FlavorOSFamily.count }.by(0)
       end
     end
+
+    describe 'destroy' do
+      let(:flavor) { create(:flavor) }
+      let(:os_family) { Atmosphere::OSFamily.first }
+
+      it 'removes all pricing information together with a flavor' do
+        flavor.set_hourly_cost_for(Atmosphere::OSFamily.first, 100)
+        flavor.set_hourly_cost_for(Atmosphere::OSFamily.second, 500)
+        expect(Atmosphere::FlavorOSFamily.count).to eq 2
+        expect{ flavor.destroy }.
+          to change { Atmosphere::FlavorOSFamily.count }.by(-2)
+      end
+
+      it 'should never perish when serving a running vm' do
+        create(:virtual_machine,
+               managed_by_atmosphere: true,
+               virtual_machine_flavor: flavor)
+        expect(flavor.virtual_machines.count).to eq 1
+        expect{ flavor.destroy }.
+          to change { Atmosphere::VirtualMachineFlavor.count }.by(0)
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #182 

Also prevents VMF.destroy if there are VMs attached to that flavor.