### PR TITLE
Use optimizer services

### DIFF
--- a/app/controllers/atmosphere/admin/appliance_sets_controller.rb
+++ b/app/controllers/atmosphere/admin/appliance_sets_controller.rb
@@ -26,7 +26,7 @@ class Atmosphere::Admin::ApplianceSetsController < Atmosphere::Admin::Applicatio
 
   # DELETE /admin/appliance_sets/1
   def destroy
-    @appliance_set.destroy
+    Atmosphere::DestroyApplianceSet.new(@appliance_set).execute
     redirect_to admin_appliance_sets_url, notice: 'ApplianceSet was successfully destroyed.'
   end
 

--- a/app/controllers/atmosphere/api/v1/appliance_sets_controller.rb
+++ b/app/controllers/atmosphere/api/v1/appliance_sets_controller.rb
@@ -40,7 +40,7 @@ module Atmosphere
         end
 
         def destroy
-          if @appliance_set.destroy
+          if Atmosphere::DestroyApplianceSet.new(@appliance_set).execute
             render json: {}
           else
             render_error @appliance_set

--- a/app/controllers/atmosphere/api/v1/appliances_controller.rb
+++ b/app/controllers/atmosphere/api/v1/appliances_controller.rb
@@ -29,7 +29,7 @@ class Atmosphere::Api::V1::AppliancesController < Atmosphere::Api::ApplicationCo
   end
 
   def destroy
-    if @appliance.destroy
+    if Atmosphere::DestroyAppliance.new(@appliance).execute
       render json: {}
     else
       render_error @appliance

--- a/app/controllers/atmosphere/api/v1/appliances_controller.rb
+++ b/app/controllers/atmosphere/api/v1/appliances_controller.rb
@@ -71,7 +71,10 @@ class Atmosphere::Api::V1::AppliancesController < Atmosphere::Api::ApplicationCo
 
   def scale
     authorize!(:scale, @appliance)
-    optimizer.run(scaling: { appliance: @appliance, quantity: params[:scale].to_i })
+
+    Atmosphere::Cloud::ScaleAppliance.
+      new(@appliance, params[:scale].to_i).execute
+
     render json: {}, status: 200
   end
 

--- a/app/models/atmosphere/appliance_set.rb
+++ b/app/models/atmosphere/appliance_set.rb
@@ -19,7 +19,6 @@ module Atmosphere
         class_name: 'Atmosphere::User'
 
     has_many :appliances,
-        dependent: :destroy,
         class_name: 'Atmosphere::Appliance'
 
     validates :user, presence: true

--- a/app/services/atmosphere/destroy_appliance.rb
+++ b/app/services/atmosphere/destroy_appliance.rb
@@ -8,7 +8,7 @@ module Atmosphere
 
     def execute
       @billing_service.bill_appliance(@appliance, Time.now.utc,
-                                    I18n.t('billing.final'), false)
+                                      I18n.t('billing.final'), false)
 
       @appliance.destroy.tap do |success|
         @vm_cleaner.execute if success

--- a/app/services/atmosphere/destroy_appliance.rb
+++ b/app/services/atmosphere/destroy_appliance.rb
@@ -1,0 +1,18 @@
+module Atmosphere
+  class DestroyAppliance
+    def initialize(appliance, options = {})
+      @appliance = appliance
+      @billing_service = options.fetch(:billing_service, BillingService)
+      @vm_cleaner = options.fetch(:vm_cleaner, Cloud::DestroyUnusedVms).new
+    end
+
+    def execute
+      @billing_service.bill_appliance(@appliance, Time.now.utc,
+                                    I18n.t('billing.final'), false)
+
+      @appliance.destroy.tap do |success|
+        @vm_cleaner.execute if success
+      end
+    end
+  end
+end

--- a/app/services/atmosphere/destroy_appliance_set.rb
+++ b/app/services/atmosphere/destroy_appliance_set.rb
@@ -1,0 +1,19 @@
+module Atmosphere
+  class DestroyApplianceSet
+    def initialize(appliance_set)
+      @appliance_set = appliance_set
+    end
+
+    def execute
+      @appliance_set.appliances.each do |appliance|
+        unless DestroyAppliance.new(appliance).execute
+          @appliance_set.errors.
+            add(I18n.t('appliance_seta.cannot_remote_appliance',
+                       appliance: appliance))
+        end
+      end
+
+      @appliance_set.destroy
+    end
+  end
+end

--- a/app/services/atmosphere/destroy_appliance_set.rb
+++ b/app/services/atmosphere/destroy_appliance_set.rb
@@ -8,7 +8,7 @@ module Atmosphere
       @appliance_set.appliances.each do |appliance|
         unless DestroyAppliance.new(appliance).execute
           @appliance_set.errors.
-            add(I18n.t('appliance_seta.cannot_remote_appliance',
+            add(I18n.t('appliance_sets.cannot_remove_appliance',
                        appliance: appliance))
         end
       end

--- a/app/services/atmosphere/optimizer.rb
+++ b/app/services/atmosphere/optimizer.rb
@@ -9,7 +9,6 @@ module Atmosphere
     def run(hint)
       satisfy_appliance(hint[:created_appliance]) if hint[:created_appliance]
       terminate_unused_vms if hint[:destroyed_appliance]
-      scale(hint[:scaling]) if hint[:scaling]
     end
 
     #private
@@ -28,11 +27,6 @@ module Atmosphere
 
     def select_tmpls_and_flavors(tmpls, options={})
       OptimizationStrategy::Default.select_tmpls_and_flavors(tmpls, options)
-    end
-
-    def scale(hint)
-      Atmosphere::Cloud::ScaleAppliance.
-        new(hint[:appliance], hint[:quantity]).execute
     end
 
     private

--- a/app/services/atmosphere/optimizer.rb
+++ b/app/services/atmosphere/optimizer.rb
@@ -8,16 +8,11 @@ module Atmosphere
     # :appliance_id DB id of the appliance that was created. Optimization only akes care of finding a vm or creating a new one for given appliance.
     def run(hint)
       satisfy_appliance(hint[:created_appliance]) if hint[:created_appliance]
-      terminate_unused_vms if hint[:destroyed_appliance]
     end
 
     #private
     def satisfy_appliance(appliance)
       Atmosphere::Cloud::SatisfyAppliance.new(appliance).execute
-    end
-
-    def terminate_unused_vms
-      Atmosphere::Cloud::DestroyUnusedVms.new.execute
     end
 
     def select_tmpl_and_flavor(tmpls, options={})

--- a/app/services/atmosphere/optimizer.rb
+++ b/app/services/atmosphere/optimizer.rb
@@ -23,11 +23,5 @@ module Atmosphere
     def select_tmpls_and_flavors(tmpls, options={})
       OptimizationStrategy::Default.select_tmpls_and_flavors(tmpls, options)
     end
-
-    private
-
-    def logger
-      Atmosphere.optimizer_logger
-    end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -103,7 +103,7 @@ en:
     show: Show this Appliance Set
     edit: Edit this Appliance Set
     remove: Remove this Appliance Set
-    cannot_remote_appliance: "Unable to remove %{appliance.name} (%{appliance.id})"
+    cannot_remove_appliance: "Unable to remove %{appliance.name} (%{appliance.id})"
   compute_sites:
     title: Sites
     long_title: Compute Sites and Pricing

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -103,6 +103,7 @@ en:
     show: Show this Appliance Set
     edit: Edit this Appliance Set
     remove: Remove this Appliance Set
+    cannot_remote_appliance: "Unable to remove %{appliance.name} (%{appliance.id})"
   compute_sites:
     title: Sites
     long_title: Compute Sites and Pricing

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -323,3 +323,6 @@ en:
     not_allowed: "Scaling not allowed"
     not_allowed_description: "Chosen optimization strategy does not allow for manual scaling"
     manual_not_allowed: Manual scaling is not allowed for selected appliance scaling policy
+
+  billing:
+    final: Final billing action prior to appliance destruction.

--- a/spec/models/atmosphere/appliance_set_spec.rb
+++ b/spec/models/atmosphere/appliance_set_spec.rb
@@ -47,6 +47,6 @@ describe Atmosphere::ApplianceSet do
 
   it { should belong_to :user }
   it { should validate_presence_of :user }
-  it { should have_many(:appliances).dependent(:destroy) }
+  it { should have_many(:appliances) }
 
 end

--- a/spec/models/atmosphere/appliance_spec.rb
+++ b/spec/models/atmosphere/appliance_spec.rb
@@ -72,7 +72,7 @@ describe Atmosphere::Appliance do
   context 'appliance configuration instances management' do
     before do
       allow(Atmosphere::Optimizer).to receive(:instance).and_return(optimizer)
-      expect(optimizer).to receive(:run).twice
+      allow(optimizer).to receive(:run)
     end
     let!(:appliance) { create(:appliance) }
 

--- a/spec/requests/atmosphere/api/appliances_spec.rb
+++ b/spec/requests/atmosphere/api/appliances_spec.rb
@@ -627,16 +627,16 @@ describe Atmosphere::Api::V1::AppliancesController do
       appliance = appliance_for(user, mode: :development)
 
       expect_scale_action(appliance, 1)
-      post api("/appliances/#{appliance.id}/action", user), { scale: 1 }
+      post api("/appliances/#{appliance.id}/action", user), scale: 1
       expect(response.status).to eq 200
     end
 
     it 'scales down' do
       appliance = appliance_for(user, mode: :development)
-      vm = create(:virtual_machine, appliances: [appliance])
+      create(:virtual_machine, appliances: [appliance])
 
       expect_scale_action(appliance, -1)
-      post api("/appliances/#{appliance.id}/action", user), { scale: -1 }
+      post api("/appliances/#{appliance.id}/action", user), scale: -1
       expect(response.status).to eq 200
     end
 

--- a/spec/services/atmosphere/billing_service_spec.rb
+++ b/spec/services/atmosphere/billing_service_spec.rb
@@ -328,7 +328,7 @@ describe Atmosphere::BillingService do
       appl1.deployments.first.prepaid_until = Time.now - 30.minutes
       appl1.save
 
-      appl1.destroy
+      Atmosphere::DestroyAppliance.new(appl1).execute
 
       expect(Atmosphere::BillingLog.all.count).to eq 2
 

--- a/spec/services/atmosphere/destroy_appliance_set_spec.rb
+++ b/spec/services/atmosphere/destroy_appliance_set_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe Atmosphere::DestroyApplianceSet do
+  it 'removes appliance set' do
+    as = create(:appliance_set)
+    expect { Atmosphere::DestroyApplianceSet.new(as).execute }.
+      to change { Atmosphere::ApplianceSet.count }.by(-1)
+  end
+
+  it 'removes connected appliances' do
+    appl1, appl2 = build(:appliance), build(:appliance)
+    as = build(:appliance_set, appliances: [appl1, appl2])
+
+    expect_appliance_destroy(appl1)
+    expect_appliance_destroy(appl2)
+
+    Atmosphere::DestroyApplianceSet.new(as).execute
+  end
+
+  def expect_appliance_destroy(appliance)
+    destroyer = double('appliance destroyer')
+    expect(destroyer).to receive(:execute).and_return(true)
+    expect(Atmosphere::DestroyAppliance).
+      to receive(:new).with(appliance).
+      and_return(destroyer)
+  end
+end

--- a/spec/services/atmosphere/destroy_appliance_spec.rb
+++ b/spec/services/atmosphere/destroy_appliance_spec.rb
@@ -19,7 +19,7 @@ describe Atmosphere::DestroyAppliance do
   it 'bills appliance' do
     expect(billing_service).
       to receive(:bill_appliance).
-      with(appliance, anything(), anything(), false)
+      with(appliance, anything, anything, false)
 
     subject.execute
   end

--- a/spec/services/atmosphere/destroy_appliance_spec.rb
+++ b/spec/services/atmosphere/destroy_appliance_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+describe Atmosphere::DestroyAppliance do
+  let!(:appliance) { create(:appliance) }
+
+  let(:billing_service) do
+    double(bill_appliance: true)
+  end
+
+  let(:vm_cleaner) do
+    double(Atmosphere::Cloud::DestroyUnusedVms, new: double(execute: true))
+  end
+
+  subject do
+    Atmosphere::DestroyAppliance.
+      new(appliance, billing_service: billing_service, vm_cleaner: vm_cleaner)
+  end
+
+  it 'bills appliance' do
+    expect(billing_service).
+      to receive(:bill_appliance).
+      with(appliance, anything(), anything(), false)
+
+    subject.execute
+  end
+
+  it 'removes appliance' do
+    expect { subject.execute }.to change { Atmosphere::Appliance.count }.by(-1)
+  end
+
+  it 'cleans unused vms' do
+    cleaner = instance_double(Atmosphere::Cloud::DestroyUnusedVms)
+    expect(cleaner).to receive(:execute)
+    expect(vm_cleaner).to receive(:new).and_return(cleaner)
+
+    subject.execute
+  end
+end

--- a/spec/services/atmosphere/optimizer_spec.rb
+++ b/spec/services/atmosphere/optimizer_spec.rb
@@ -20,24 +20,6 @@ describe Atmosphere::Optimizer do
      expect(subject).not_to be_nil
   end
 
-  context 'virtual machine is applianceless' do
-    let!(:external_vm) { create(:virtual_machine) }
-    let!(:vm) { create(:virtual_machine, managed_by_atmosphere: true) }
-
-    before do
-      servers_double = double
-      allow(vm.compute_site.cloud_client)
-        .to receive(:servers).and_return(servers_double)
-      allow(servers_double).to receive(:destroy)
-    end
-
-    it 'terminates unused manageable vm' do
-      subject.run(destroyed_appliance: true)
-
-      expect(Atmosphere::Cloud::VmDestroyWorker).to have_enqueued_job(vm.id)
-    end
-  end
-
   context 'flavor' do
     let(:appl_type) { create(:appliance_type, preference_memory: 1024, preference_cpu: 2) }
     let(:appl_vm_manager) do


### PR DESCRIPTION
Code for scaling and destroying unused VM was removed from optimizer and appliance callbacks and moved into dedicated services. 