### PR TITLE
Mention about using factories in dependent projects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ group :test do
   gem "generator_spec"
 
   # gem 'factory_girl'
-  gem 'ffaker'
+  gem 'ffaker', '~>2.0.0'
   gem 'database_cleaner'
 
   gem "codeclimate-test-reporter", require: nil

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -511,7 +511,7 @@ DEPENDENCIES
   codeclimate-test-reporter
   database_cleaner
   factory_girl_rails
-  ffaker
+  ffaker (~> 2.0.0)
   foreman
   generator_spec
   guard-rspec

--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ bundle update atmosphere
 rake db:migrate
 ```
 
+## Using atmosphere factories
+
+Atmosphere factories are exposed into dependent projects in `test` environment. To use them you need to define following dependency in your `Gemfile`:
+
+```ruby
+gem 'ffaker', '~>2.0.0'
+```
+
 ## Contributing
 
 1. Fork the project


### PR DESCRIPTION
We need `ffaker` in version at least 2.0.0. This dependency need to be installed in dependent project to use atmosphere factories.

/cc @dice-cyfronet/atmo-dev-team please take a look.

Fixes #153