### PR TITLE
Don't allow to modify fund name after it is created

### DIFF
--- a/app/controllers/atmosphere/admin/funds_controller.rb
+++ b/app/controllers/atmosphere/admin/funds_controller.rb
@@ -25,7 +25,7 @@ class Atmosphere::Admin::FundsController < Atmosphere::Admin::ApplicationControl
 
   # PATCH/PUT /funds/1
   def update
-    if @fund.update(fund_params)
+    if @fund.update(update_params)
       redirect_to admin_funds_path, notice: t('funds.update.success')
     else
       render action: 'edit'
@@ -40,6 +40,12 @@ class Atmosphere::Admin::FundsController < Atmosphere::Admin::ApplicationControl
 
 
   private
+
+  def update_params
+    params.require(:fund).
+      permit(:balance, :overdraft_limit,
+             :currency_label, :termination_policy)
+  end
 
   def fund_params
     params.require(:fund).permit(

--- a/app/models/atmosphere/fund.rb
+++ b/app/models/atmosphere/fund.rb
@@ -56,6 +56,8 @@ module Atmosphere
               in: [:delete, :suspend, :no_action],
               predicates: true
 
+    attr_readonly :name
+
     def unsupported_tenants
       Tenant.where.not(id: tenants)
     end

--- a/app/views/atmosphere/admin/funds/_form.html.haml
+++ b/app/views/atmosphere/admin/funds/_form.html.haml
@@ -2,7 +2,7 @@
   = f.error_notification
 
   .inputs
-    = f.input :name
+    = f.input :name, disabled: !@fund.new_record?
     .col-xs-4
       = f.input :balance, as: :integer
     .col-xs-4


### PR DESCRIPTION
Fund name is used in plgrid to distinguish default team fund. That is why there should not be possible to edit fund name. I believe that is does not have any drawbacks in other projects.