### PR TITLE
Use tenant `site_id` to generate redirus tasks

### DIFF
--- a/app/models/atmosphere/http_mapping.rb
+++ b/app/models/atmosphere/http_mapping.rb
@@ -96,11 +96,16 @@ module Atmosphere
     end
 
     def rm_proxy(name)
-      Sidekiq::Client.push('queue' => tenant.tenant_id, 'class' => Redirus::Worker::RmProxy, 'args' => [name, application_protocol])
+      Sidekiq::Client.push('queue' => tenant.site_id,
+                           'class' => Redirus::Worker::RmProxy,
+                           'args' => [name, application_protocol])
     end
 
     def add_proxy(name, ips=nil)
-      Sidekiq::Client.push('queue' => tenant.tenant_id, 'class' => Redirus::Worker::AddProxy, 'args' => [name, workers(ips), application_protocol, properties])
+      Sidekiq::Client.push('queue' => tenant.site_id,
+                           'class' => Redirus::Worker::AddProxy,
+                           'args' => [name, workers(ips),
+                                      application_protocol, properties])
     end
 
     def has_workers?(ips)

--- a/spec/factories/tenants.rb
+++ b/spec/factories/tenants.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :tenant, aliases: [:openstack_tenant], class: 'Atmosphere::Tenant' do |f|
     tenant_type 'private'
     tenant_id { SecureRandom.hex(4) }
-    site_id { 'somesite' }
+    site_id { "site_id_#{SecureRandom.hex(4)}" }
     network_id { SecureRandom.hex(8) }
     name { SecureRandom.hex(4) }
     technology 'openstack'

--- a/spec/services/atmosphere/proxy/appliance_proxy_updater_spec.rb
+++ b/spec/services/atmosphere/proxy/appliance_proxy_updater_spec.rb
@@ -94,7 +94,7 @@ describe Atmosphere::Proxy::ApplianceProxyUpdater do
         http_mapping = appl.http_mappings.find_by(port_mapping_template: http)
 
         expect(Sidekiq::Client).to have_received(:push).exactly(4).times do |options|
-          expect(options['queue']).to eq http_mapping.tenant.tenant_id
+          expect(options['queue']).to eq http_mapping.tenant.site_id
         end
       end
     end


### PR DESCRIPTION
Site is can be shared among many tenants. It is used distinguish correct Redis queue name to generate add/remove http/https proxies jobs.