### PR TITLE
Scope vmts by user funds

### DIFF
--- a/app/controllers/atmosphere/api/v1/appliance_types_controller.rb
+++ b/app/controllers/atmosphere/api/v1/appliance_types_controller.rb
@@ -19,7 +19,9 @@ module Atmosphere
           process_saving_query
 
           ats = @appliance_types.where(filter).order(:id)
-          respond_with pdp.filter(ats, params[:mode])
+          respond_with pdp.filter(ats, params[:mode]),
+                       each_serializer: Atmosphere::ApplianceTypeSerializer,
+                       load_all?: load_all?
         end
 
         def show

--- a/app/controllers/atmosphere/api/v1/appliances_controller.rb
+++ b/app/controllers/atmosphere/api/v1/appliances_controller.rb
@@ -108,6 +108,10 @@ class Atmosphere::Api::V1::AppliancesController < Atmosphere::Api::ApplicationCo
   end
 
   def build_appliance
+    # The following rewrite is done to maintain compatibility with old clients
+    if params[:appliance].keys.include? 'compute_site_ids'
+      params[:appliance]['tenant_ids'] = params[:appliance]['compute_site_ids']
+    end
     @appliance = Atmosphere::ApplianceCreator.
                   new(params.require(:appliance), delegate_auth).build
   end

--- a/app/controllers/atmosphere/api/v1/appliances_controller.rb
+++ b/app/controllers/atmosphere/api/v1/appliances_controller.rb
@@ -110,7 +110,7 @@ class Atmosphere::Api::V1::AppliancesController < Atmosphere::Api::ApplicationCo
   def build_appliance
     # The following rewrite is done to maintain compatibility with old clients
     if params[:appliance].keys.include? 'compute_site_ids'
-      params[:appliance]['tenant_ids'] = params[:appliance]['compute_site_ids']
+      params[:appliance]['tenant_ids'] = params[:appliance].delete('compute_site_ids')
     end
     @appliance = Atmosphere::ApplianceCreator.
                   new(params.require(:appliance), delegate_auth).build

--- a/app/controllers/atmosphere/api/v1/clew_controller.rb
+++ b/app/controllers/atmosphere/api/v1/clew_controller.rb
@@ -24,7 +24,7 @@ module Atmosphere
         def appliance_types
           appliance_types = @appliance_types.active.includes(:tenants).references(:tenants).
               includes(:appliance_configuration_templates).references(:appliance_configuration_templates).
-              where(atmosphere_tenants: { id: current_user.tenants }).order(:id)
+              where(atmosphere_tenants: { id: current_user.tenants.active }).order(:id)
           appliance_types = pdp.filter(appliance_types, params[:mode])
           render json: { appliance_types: appliance_types }, serializer: ClewApplianceTypesSerializer
         end

--- a/app/controllers/atmosphere/api/v1/clew_controller.rb
+++ b/app/controllers/atmosphere/api/v1/clew_controller.rb
@@ -23,7 +23,8 @@ module Atmosphere
 
         def appliance_types
           appliance_types = @appliance_types.active.includes(:tenants).references(:tenants).
-              includes(:appliance_configuration_templates).references(:appliance_configuration_templates).order(:id)
+              includes(:appliance_configuration_templates).references(:appliance_configuration_templates).
+              where(atmosphere_tenants: { id: current_user.tenants }).order(:id)
           appliance_types = pdp.filter(appliance_types, params[:mode])
           render json: { appliance_types: appliance_types }, serializer: ClewApplianceTypesSerializer
         end

--- a/app/controllers/atmosphere/api/v1/clew_controller.rb
+++ b/app/controllers/atmosphere/api/v1/clew_controller.rb
@@ -22,8 +22,9 @@ module Atmosphere
         end
 
         def appliance_types
-          appliance_types = @appliance_types.active.includes(:tenants).references(:tenants).
-              includes(:appliance_configuration_templates).references(:appliance_configuration_templates).
+          appliance_types = @appliance_types.active.
+              includes(:tenants, :appliance_configuration_templates).
+              references(:tenants, :appliance_configuration_templates).
               where(atmosphere_tenants: { id: current_user.tenants.active }).order(:id)
           appliance_types = pdp.filter(appliance_types, params[:mode])
           render json: { appliance_types: appliance_types }, serializer: ClewApplianceTypesSerializer

--- a/app/controllers/atmosphere/api/v1/virtual_machine_templates_controller.rb
+++ b/app/controllers/atmosphere/api/v1/virtual_machine_templates_controller.rb
@@ -5,10 +5,18 @@ class Atmosphere::Api::V1::VirtualMachineTemplatesController  < Atmosphere::Api:
   respond_to :json
 
   def index
-    respond_with @virtual_machine_templates.where(filter).order(:id)
+    respond_with @virtual_machine_templates.joins(:tenants).where(filter).order(:id)
   end
 
   def model_class
     Atmosphere::VirtualMachineTemplate
+  end
+
+  private
+
+  def filter
+    filter = super
+    filter[:atmosphere_tenants] = { id: current_user.tenants } unless current_user.has_role?(:admin)
+    filter
   end
 end

--- a/app/controllers/atmosphere/api/v1/virtual_machine_templates_controller.rb
+++ b/app/controllers/atmosphere/api/v1/virtual_machine_templates_controller.rb
@@ -6,7 +6,7 @@ class Atmosphere::Api::V1::VirtualMachineTemplatesController  < Atmosphere::Api:
 
   def index
     respond_with @virtual_machine_templates.joins(:tenants).where(filter).
-      order(:id),
+                     order(:id),
       each_serializer: Atmosphere::VirtualMachineTemplateSerializer,
       load_all?: load_all?
   end

--- a/app/controllers/atmosphere/api/v1/virtual_machine_templates_controller.rb
+++ b/app/controllers/atmosphere/api/v1/virtual_machine_templates_controller.rb
@@ -5,9 +5,10 @@ class Atmosphere::Api::V1::VirtualMachineTemplatesController  < Atmosphere::Api:
   respond_to :json
 
   def index
-    respond_with @virtual_machine_templates.joins(:tenants).where(filter).order(:id),
-                 each_serializer: Atmosphere::VirtualMachineTemplateSerializer,
-                 load_all?: load_all?
+    respond_with @virtual_machine_templates.joins(:tenants).where(filter).
+      order(:id),
+      each_serializer: Atmosphere::VirtualMachineTemplateSerializer,
+      load_all?: load_all?
   end
 
   def model_class

--- a/app/controllers/atmosphere/api/v1/virtual_machine_templates_controller.rb
+++ b/app/controllers/atmosphere/api/v1/virtual_machine_templates_controller.rb
@@ -5,7 +5,9 @@ class Atmosphere::Api::V1::VirtualMachineTemplatesController  < Atmosphere::Api:
   respond_to :json
 
   def index
-    respond_with @virtual_machine_templates.joins(:tenants).where(filter).order(:id)
+    respond_with @virtual_machine_templates.joins(:tenants).where(filter).order(:id),
+                 each_serializer: Atmosphere::VirtualMachineTemplateSerializer,
+                 load_all?: load_all?
   end
 
   def model_class
@@ -16,7 +18,7 @@ class Atmosphere::Api::V1::VirtualMachineTemplatesController  < Atmosphere::Api:
 
   def filter
     filter = super
-    filter[:atmosphere_tenants] = { id: current_user.tenants } unless current_user.has_role?(:admin)
+    filter[:atmosphere_tenants] = { id: current_user.tenants } unless load_all?
     filter
   end
 end

--- a/app/models/atmosphere/user.rb
+++ b/app/models/atmosphere/user.rb
@@ -108,6 +108,10 @@ module Atmosphere
       Atmosphere::Tenant.joins(funds: :users).where("atmosphere_users.id = #{id}")
     end
 
+    def tenant_ids
+      tenants.pluck(&:id)
+    end
+
     private
 
     # Checks whether any fund has been assigned to this user.

--- a/app/providers/atmosphere/optimization_strategy/default.rb
+++ b/app/providers/atmosphere/optimization_strategy/default.rb
@@ -20,7 +20,7 @@ module Atmosphere
       end
 
       def new_vms_tmpls_and_flavors_and_tenants
-        tmpls = vmt_candidates_for(appliance)
+        tmpls = vmt_candidates
         return [{template: nil, flavor: nil, tenant: nil}] if tmpls.blank?
 
         Default.select_tmpls_and_flavors_and_tenants(tmpls, appliance, preferences)

--- a/app/serializers/atmosphere/appliance_type_serializer.rb
+++ b/app/serializers/atmosphere/appliance_type_serializer.rb
@@ -38,10 +38,10 @@ module Atmosphere
 
     def compute_site_ids
       ts = object.tenants.active
-      unless @options[:load_all?]
-        ts = ts & current_user.tenants
+      unless options[:load_all?]
+        ts = ts.where(id: scope.tenants)
       end
-      ts.map(&:id)
+      ts.pluck(:id)
     end
   end
 end

--- a/app/serializers/atmosphere/appliance_type_serializer.rb
+++ b/app/serializers/atmosphere/appliance_type_serializer.rb
@@ -38,7 +38,7 @@ module Atmosphere
 
     def compute_site_ids
       ts = object.tenants.active
-      if !(@options[:load_all?])
+      unless @options[:load_all?]
         ts = ts & current_user.tenants
       end
       ts.map(&:id)

--- a/app/serializers/atmosphere/appliance_type_serializer.rb
+++ b/app/serializers/atmosphere/appliance_type_serializer.rb
@@ -38,7 +38,7 @@ module Atmosphere
 
     def compute_site_ids
       ts = object.tenants.active
-      if (defined? current_user) && !(:load_all?)
+      if !(@options[:load_all?])
         ts = ts & current_user.tenants
       end
       ts.map(&:id)

--- a/app/serializers/atmosphere/appliance_type_serializer.rb
+++ b/app/serializers/atmosphere/appliance_type_serializer.rb
@@ -10,12 +10,11 @@ module Atmosphere
                :shared, :scalable, :visible_to, :author_id
     attributes :preference_cpu, :preference_memory, :preference_disk
     attributes :active, :saving
+    attributes :compute_site_ids
 
     has_many :appliances, :port_mapping_templates,
              :appliance_configuration_templates,
              :virtual_machine_templates
-
-    has_many :tenants, key: :compute_site_ids
 
     private
 
@@ -37,8 +36,12 @@ module Atmosphere
           count > 0
     end
 
-    def tenants
-      object.tenants.active
+    def compute_site_ids
+      ts = object.tenants.active
+      if defined? current_user and !(:load_all?)
+        ts = ts & current_user.tenants
+      end
+      ts.map(&:id)
     end
   end
 end

--- a/app/serializers/atmosphere/appliance_type_serializer.rb
+++ b/app/serializers/atmosphere/appliance_type_serializer.rb
@@ -38,7 +38,7 @@ module Atmosphere
 
     def compute_site_ids
       ts = object.tenants.active
-      if defined? current_user and !(:load_all?)
+      if (defined? current_user) && !(:load_all?)
         ts = ts & current_user.tenants
       end
       ts.map(&:id)

--- a/app/serializers/atmosphere/clew_appliance_types_serializer.rb
+++ b/app/serializers/atmosphere/clew_appliance_types_serializer.rb
@@ -19,7 +19,7 @@ module Atmosphere
         preference_memory: at.preference_memory,
         preference_disk: at.preference_disk,
         matched_flavor: map_flavor(flavor),
-        compute_site_ids: at.tenant_ids,
+        compute_site_ids: at.tenant_ids & current_user.tenants.map(&:id),
         appliance_configuration_templates: at.appliance_configuration_templates
       }
     end

--- a/app/serializers/atmosphere/clew_appliance_types_serializer.rb
+++ b/app/serializers/atmosphere/clew_appliance_types_serializer.rb
@@ -19,7 +19,7 @@ module Atmosphere
         preference_memory: at.preference_memory,
         preference_disk: at.preference_disk,
         matched_flavor: map_flavor(flavor),
-        compute_site_ids: at.tenant_ids & current_user.tenants.map(&:id),
+        compute_site_ids: at.tenant_ids & current_user.tenants.active.map(&:id),
         appliance_configuration_templates: at.appliance_configuration_templates
       }
     end

--- a/app/serializers/atmosphere/virtual_machine_template_serializer.rb
+++ b/app/serializers/atmosphere/virtual_machine_template_serializer.rb
@@ -12,7 +12,7 @@ module Atmosphere
 
     def compute_site_id
       ts = object.tenants.active
-      if !(options[:load_all?])
+      unless options[:load_all?]
         ts = ts & current_user.tenants
       end
       ts.blank? ? nil : ts.first.id

--- a/app/serializers/atmosphere/virtual_machine_template_serializer.rb
+++ b/app/serializers/atmosphere/virtual_machine_template_serializer.rb
@@ -11,8 +11,8 @@ module Atmosphere
     has_one :appliance_type
 
     def compute_site_id
-      ts = object.tenants
-      if defined? current_user && !(options[:load_all?])
+      ts = object.tenants.active
+      if !(options[:load_all?])
         ts = ts & current_user.tenants
       end
       ts.blank? ? nil : ts.first.id

--- a/app/serializers/atmosphere/virtual_machine_template_serializer.rb
+++ b/app/serializers/atmosphere/virtual_machine_template_serializer.rb
@@ -13,7 +13,7 @@ module Atmosphere
     def compute_site_id
       ts = object.tenants.active
       unless options[:load_all?]
-        ts = ts & current_user.tenants
+        ts = ts.where(id: scope.tenants)
       end
       ts.blank? ? nil : ts.first.id
     end

--- a/app/serializers/atmosphere/virtual_machine_template_serializer.rb
+++ b/app/serializers/atmosphere/virtual_machine_template_serializer.rb
@@ -10,10 +10,9 @@ module Atmosphere
 
     has_one :appliance_type
 
-
     def compute_site_id
       ts = object.tenants
-      if defined? current_user and !(options[:load_all?])
+      if defined? current_user && !(options[:load_all?])
         ts = ts & current_user.tenants
       end
       ts.blank? ? nil : ts.first.id

--- a/app/serializers/atmosphere/virtual_machine_template_serializer.rb
+++ b/app/serializers/atmosphere/virtual_machine_template_serializer.rb
@@ -10,8 +10,13 @@ module Atmosphere
 
     has_one :appliance_type
 
+
     def compute_site_id
-      object.tenants.first.id
+      ts = object.tenants
+      if defined? current_user and !(options[:load_all?])
+        ts = ts & current_user.tenants
+      end
+      ts.blank? ? nil : ts.first.id
     end
   end
 end

--- a/spec/requests/atmosphere/api/appliance_types_spec.rb
+++ b/spec/requests/atmosphere/api/appliance_types_spec.rb
@@ -243,9 +243,10 @@ describe Atmosphere::Api::V1::ApplianceTypesController do
       end
 
       it 'returns compute sites for appliance type' do
-        user = create(:user)
-        t1  = create(:tenant)
-        t2  = create(:tenant)
+        f = create(:fund)
+        user = create(:user, funds: [f])
+        t1  = create(:tenant, funds: [f])
+        t2  = create(:tenant, funds: [f])
         at   = create(:appliance_type, visible_to: :all)
         create(:virtual_machine_template, tenants: [t1], appliance_type: at)
         create(:virtual_machine_template, tenants: [t2], appliance_type: at)
@@ -257,9 +258,9 @@ describe Atmosphere::Api::V1::ApplianceTypesController do
       end
 
       it 'does not return the same compute site twice for appliance type' do
-        user = create(:user)
-        t1  = create(:tenant)
-
+        f = create(:fund)
+        user = create(:user, funds: [f])
+        t1  = create(:tenant, funds: [f])
         at  = create(:appliance_type, visible_to: :all)
         create(:virtual_machine_template, tenants: [t1], appliance_type: at)
         create(:virtual_machine_template, tenants: [t1], appliance_type: at)

--- a/spec/requests/atmosphere/api/appliance_types_spec.rb
+++ b/spec/requests/atmosphere/api/appliance_types_spec.rb
@@ -245,9 +245,9 @@ describe Atmosphere::Api::V1::ApplianceTypesController do
       it 'returns compute sites for appliance type' do
         f = create(:fund)
         user = create(:user, funds: [f])
-        t1  = create(:tenant, funds: [f])
-        t2  = create(:tenant, funds: [f])
-        at   = create(:appliance_type, visible_to: :all)
+        t1 = create(:tenant, funds: [f])
+        t2 = create(:tenant, funds: [f])
+        at = create(:appliance_type, visible_to: :all)
         create(:virtual_machine_template, tenants: [t1], appliance_type: at)
         create(:virtual_machine_template, tenants: [t2], appliance_type: at)
 
@@ -260,8 +260,8 @@ describe Atmosphere::Api::V1::ApplianceTypesController do
       it 'does not return the same compute site twice for appliance type' do
         f = create(:fund)
         user = create(:user, funds: [f])
-        t1  = create(:tenant, funds: [f])
-        at  = create(:appliance_type, visible_to: :all)
+        t1 = create(:tenant, funds: [f])
+        at = create(:appliance_type, visible_to: :all)
         create(:virtual_machine_template, tenants: [t1], appliance_type: at)
         create(:virtual_machine_template, tenants: [t1], appliance_type: at)
 

--- a/spec/requests/atmosphere/api/appliances_spec.rb
+++ b/spec/requests/atmosphere/api/appliances_spec.rb
@@ -397,10 +397,10 @@ describe Atmosphere::Api::V1::AppliancesController do
 
     context 'with_selected_compute_sites' do
 
-      let!(:tenant_1) {create(:tenant)}
-      let!(:tenant_2) {create(:tenant)}
-      let!(:tenant_3) {create(:tenant)}
-      let!(:tenant_4) {create(:tenant)}
+      let!(:tenant_1) { create(:tenant) }
+      let!(:tenant_2) { create(:tenant) }
+      let!(:tenant_3) { create(:tenant) }
+      let!(:tenant_4) { create(:tenant) }
 
       let!(:static_dev_request_body_with_one_ts) do
         {
@@ -433,7 +433,7 @@ describe Atmosphere::Api::V1::AppliancesController do
       it 'creates new appliance with default t binding' do
         expect {
           post api("/appliances", user), static_request_body
-        }.to change { Atmosphere::ApplianceTenant.count}.by(4)
+        }.to change { Atmosphere::ApplianceTenant.count }.by(4)
       end
 
       it 'creates new appliance bound to one t' do

--- a/spec/requests/atmosphere/api/appliances_spec.rb
+++ b/spec/requests/atmosphere/api/appliances_spec.rb
@@ -399,6 +399,8 @@ describe Atmosphere::Api::V1::AppliancesController do
 
       let!(:tenant_1) {create(:tenant)}
       let!(:tenant_2) {create(:tenant)}
+      let!(:tenant_3) {create(:tenant)}
+      let!(:tenant_4) {create(:tenant)}
 
       let!(:static_dev_request_body_with_one_ts) do
         {
@@ -406,7 +408,7 @@ describe Atmosphere::Api::V1::AppliancesController do
                 configuration_template_id: static_config.id,
                 appliance_set_id: development_set.id,
                 fund_id: fund.id,
-                tenant_ids: [tenant_1.id]
+                compute_site_ids: [tenant_1.id]
             }
         }
       end
@@ -417,7 +419,7 @@ describe Atmosphere::Api::V1::AppliancesController do
                 configuration_template_id: static_config.id,
                 appliance_set_id: development_set.id,
                 fund_id: fund.id,
-                tenant_ids: [tenant_1.id, tenant_2.id]
+                compute_site_ids: [tenant_2.id, tenant_4.id]
             }
         }
       end
@@ -431,7 +433,7 @@ describe Atmosphere::Api::V1::AppliancesController do
       it 'creates new appliance with default t binding' do
         expect {
           post api("/appliances", user), static_request_body
-        }.to change { Atmosphere::ApplianceTenant.count}.by(2)
+        }.to change { Atmosphere::ApplianceTenant.count}.by(4)
       end
 
       it 'creates new appliance bound to one t' do
@@ -446,7 +448,6 @@ describe Atmosphere::Api::V1::AppliancesController do
         expect(a.tenants.count).to eq 2
       end
     end
-
 
     context 'user keys' do
       context 'when in production mode' do

--- a/spec/requests/atmosphere/api/clew_spec.rb
+++ b/spec/requests/atmosphere/api/clew_spec.rb
@@ -208,7 +208,8 @@ describe Atmosphere::Api::V1::ClewController do
       get api('/clew/appliance_types', user)
 
       expect(clew_at_response['appliance_types'].size).to eq 1
-      expect(clew_at_response['appliance_types'][0]['compute_site_ids']).to eq [t1.id]
+      expect(clew_at_response['appliance_types'][0]['compute_site_ids']).
+        to eq [t1.id]
       expect(clew_at_response['compute_sites'].size).to eq 1
       expect(clew_at_response['compute_sites'][0]['id']).to eq t1.id
     end

--- a/spec/requests/atmosphere/api/clew_spec.rb
+++ b/spec/requests/atmosphere/api/clew_spec.rb
@@ -214,6 +214,22 @@ describe Atmosphere::Api::V1::ClewController do
       expect(clew_at_response['compute_sites'][0]['id']).to eq t1.id
     end
 
+    it 'skips AT entirely if it has no available vmts through funds' do
+      fund1 = create(:fund)
+      fund2 = create(:fund)
+      user = create(:user, login: 'foobarbazquux', funds: [fund1])
+      t1 = create(:tenant, funds: [fund1])
+      t2 = create(:tenant, funds: [fund2])
+      at = create(:appliance_type, visible_to: :all)
+      act = create(:appliance_configuration_template, appliance_type: at)
+      vmt = create(:virtual_machine_template, appliance_type: at, tenants: [t2])
+
+      get api('/clew/appliance_types', user)
+
+      expect(clew_at_response['appliance_types'].size).to eq 0
+      expect(clew_at_response['compute_sites'].size).to eq 0
+    end
+
     def clew_at_response
       json_response['clew_appliance_types']
     end

--- a/spec/requests/atmosphere/api/clew_spec.rb
+++ b/spec/requests/atmosphere/api/clew_spec.rb
@@ -218,11 +218,11 @@ describe Atmosphere::Api::V1::ClewController do
       fund1 = create(:fund)
       fund2 = create(:fund)
       user = create(:user, login: 'foobarbazquux', funds: [fund1])
-      t1 = create(:tenant, funds: [fund1])
+      create(:tenant, funds: [fund1])
       t2 = create(:tenant, funds: [fund2])
       at = create(:appliance_type, visible_to: :all)
-      act = create(:appliance_configuration_template, appliance_type: at)
-      vmt = create(:virtual_machine_template, appliance_type: at, tenants: [t2])
+      create(:appliance_configuration_template, appliance_type: at)
+      create(:virtual_machine_template, appliance_type: at, tenants: [t2])
 
       get api('/clew/appliance_types', user)
 

--- a/spec/requests/atmosphere/api/clew_spec.rb
+++ b/spec/requests/atmosphere/api/clew_spec.rb
@@ -131,14 +131,15 @@ describe Atmosphere::Api::V1::ClewController do
     end
 
     context 'when authenticated' do
-      let!(:user) { create(:user) }
+      let!(:fund) { create(:fund) }
+      let!(:user) { create(:user, funds: [fund]) }
 
       let!(:at1)  { create(:filled_appliance_type, author: user) }
       let!(:at2)  { create(:appliance_type, visible_to: :all) }
       let!(:at3)  { create(:active_appliance_type, author: user) }
       let!(:at4)  { create(:active_appliance_type, visible_to: :all) }
 
-      let(:t) { create(:tenant) }
+      let(:t) { create(:tenant, funds: [fund]) }
 
       let!(:vmt3) { create(:virtual_machine_template, tenants: [t], appliance_type: at3) }
       let!(:vmt4) { create(:virtual_machine_template, tenants: [t], appliance_type: at4) }
@@ -160,7 +161,7 @@ describe Atmosphere::Api::V1::ClewController do
 
         expect(response.status).to eq 200
         expect(clew_at_response['appliance_types'].size).to eq 2
-        expect(clew_at_response['compute_sites'].size).to eq 3
+        expect(clew_at_response['compute_sites'].size).to eq 1
         expect(clew_at_response['appliance_types'][0]).to clew_at_eq at3
         expect(clew_at_response['appliance_types'][1]).to clew_at_eq at4
         expect(clew_at_response['appliance_types'][0]['matched_flavor']).to clew_flavor_eq  flavor
@@ -171,8 +172,9 @@ describe Atmosphere::Api::V1::ClewController do
     end
 
     it 'does not return AT with visible_to owner when user is not owner' do
-      user = create(:user)
-      t = create(:tenant)
+      fund = create(:fund)
+      user = create(:user, funds: [fund])
+      t = create(:tenant, funds: [fund])
       create(:flavor, tenant: t)
 
       owned_at = create(:appliance_type, visible_to: :owner, author: user)
@@ -186,6 +188,28 @@ describe Atmosphere::Api::V1::ClewController do
 
       expect(clew_at_response['appliance_types'].size).to eq 1
       expect(clew_at_response['appliance_types'][0]).to clew_at_eq owned_at
+    end
+
+    it 'does not reveal virtual machine templates to which the user is not linked via funds' do
+      fund = create(:fund)
+      user = create(:user, funds: [fund])
+      t1 = create(:openstack_with_flavors, funds: [fund])
+      t2 = create(:openstack_with_flavors, funds: [])
+      at1 = create(:appliance_type, visible_to: :all)
+      at2 = create(:appliance_type, visible_to: :all)
+      act1 = create(:appliance_configuration_template, appliance_type: at1)
+      act2 = create(:appliance_configuration_template, appliance_type: at2)
+
+      vmt1 = create(:virtual_machine_template, appliance_type: at1, tenants: [t1])
+      vmt2 = create(:virtual_machine_template, appliance_type: at1, tenants: [t2])
+      vmt3 = create(:virtual_machine_template, appliance_type: at1, tenants: [t1, t2])
+      vmt4 = create(:virtual_machine_template, appliance_type: at2, tenants: [t2])
+
+      get api('/clew/appliance_types', user)
+
+      expect(clew_at_response['appliance_types'].size).to eq 1
+      expect(clew_at_response['compute_sites'].size).to eq 1
+      expect(clew_at_response['compute_sites'][0]['id']).to eq t1.id
     end
 
     def clew_at_response

--- a/spec/requests/atmosphere/api/clew_spec.rb
+++ b/spec/requests/atmosphere/api/clew_spec.rb
@@ -208,6 +208,7 @@ describe Atmosphere::Api::V1::ClewController do
       get api('/clew/appliance_types', user)
 
       expect(clew_at_response['appliance_types'].size).to eq 1
+      expect(clew_at_response['appliance_types'][0]['compute_site_ids']).to eq [t1.id]
       expect(clew_at_response['compute_sites'].size).to eq 1
       expect(clew_at_response['compute_sites'][0]['id']).to eq t1.id
     end

--- a/spec/requests/atmosphere/api/virtual_machine_templates_spec.rb
+++ b/spec/requests/atmosphere/api/virtual_machine_templates_spec.rb
@@ -61,10 +61,10 @@ describe Atmosphere::Api::V1::VirtualMachineTemplatesController do
             expect(vmts[0]).to vmt_eq @vmt1
           end
 
-          it 'reveals unauthorized VMTs to admins' do
+          it 'reveals unauthorized VMTs when load_all flag is set' do
             admin = create(:user, funds: [], roles: [:admin])
 
-            get api('/virtual_machine_templates', admin)
+            get api('/virtual_machine_templates/?all=true', admin)
 
             expect(vmts.length).to eq 2
             expect(vmts[0]).to vmt_eq @vmt1

--- a/spec/serializers/atmosphere/appliance_type_serializer_spec.rb
+++ b/spec/serializers/atmosphere/appliance_type_serializer_spec.rb
@@ -37,9 +37,6 @@ describe Atmosphere::ApplianceTypeSerializer do
   private
 
   def slizer(at)
-    serializer = Atmosphere::ApplianceTypeSerializer.
-      new(at, scope: @current_user)
-    def serializer.current_user() scope end
-    serializer
+    Atmosphere::ApplianceTypeSerializer.new(at, scope: @current_user)
   end
 end

--- a/spec/serializers/atmosphere/appliance_type_serializer_spec.rb
+++ b/spec/serializers/atmosphere/appliance_type_serializer_spec.rb
@@ -6,7 +6,10 @@ describe Atmosphere::ApplianceTypeSerializer do
   it 'is inactive when all VMT started on turned off compute site' do
     _, inactive_vmt = vmt_on_tenant(t_active: false)
     at = create(:appliance_type, virtual_machine_templates: [inactive_vmt])
-    serializer = Atmosphere::ApplianceTypeSerializer.new(at)
+    #serializer = Atmosphere::ApplianceTypeSerializer.new(at)
+    @current_user = create(:user)
+
+    serializer = slizer(at)
 
     result = JSON.parse(serializer.to_json)
 
@@ -14,14 +17,30 @@ describe Atmosphere::ApplianceTypeSerializer do
   end
 
   it 'returns information about only active compute site' do
-    _, inactive_vmt = vmt_on_tenant(t_active: false)
+    f = create(:fund)
+    @current_user = create(:user, funds: [f])
+    inactive_t, inactive_vmt = vmt_on_tenant(t_active: false)
     active_t, active_vmt = vmt_on_tenant(t_active: true)
+    inactive_t.funds = [f]
+    active_t.funds = [f]
+    inactive_t.save
+    active_t.save
     at = create(:appliance_type,
       virtual_machine_templates: [inactive_vmt, active_vmt])
-    serializer = Atmosphere::ApplianceTypeSerializer.new(at)
+
+    serializer = slizer(at)
 
     result = JSON.parse(serializer.to_json)
 
     expect(result['appliance_type']['compute_site_ids']).to eq [active_t.id]
   end
+
+  private
+
+  def slizer(at)
+    serializer = Atmosphere::ApplianceTypeSerializer.new(at, { scope: @current_user })
+    def serializer.current_user() scope end
+    serializer
+  end
+
 end

--- a/spec/serializers/atmosphere/appliance_type_serializer_spec.rb
+++ b/spec/serializers/atmosphere/appliance_type_serializer_spec.rb
@@ -6,7 +6,6 @@ describe Atmosphere::ApplianceTypeSerializer do
   it 'is inactive when all VMT started on turned off compute site' do
     _, inactive_vmt = vmt_on_tenant(t_active: false)
     at = create(:appliance_type, virtual_machine_templates: [inactive_vmt])
-    #serializer = Atmosphere::ApplianceTypeSerializer.new(at)
     @current_user = create(:user)
 
     serializer = slizer(at)
@@ -38,9 +37,9 @@ describe Atmosphere::ApplianceTypeSerializer do
   private
 
   def slizer(at)
-    serializer = Atmosphere::ApplianceTypeSerializer.new(at, { scope: @current_user })
+    serializer = Atmosphere::ApplianceTypeSerializer.
+      new(at, scope: @current_user)
     def serializer.current_user() scope end
     serializer
   end
-
 end

--- a/spec/serializers/atmosphere/clew_appliance_instances_serializer_spec.rb
+++ b/spec/serializers/atmosphere/clew_appliance_instances_serializer_spec.rb
@@ -30,7 +30,6 @@ describe Atmosphere::ClewApplianceInstancesSerializer do
     as = create(:appliance_set, appliance_set_type: :portal)
     appl = create(:appliance, appliance_type: at, appliance_set: as)
     serializer = Atmosphere::ClewApplianceInstancesSerializer.new(appliance_sets: [as])
-
     result = JSON.parse(serializer.to_json)
     appl = result['clew_appliance_instances']['appliances'].first
     port_mapping_templates = appl['port_mapping_templates']

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -324,8 +324,7 @@ RSpec::Matchers.define :vmt_eq do |expected|
       actual['state'] == expected.state.to_s &&
       actual['managed_by_atmosphere'] == expected.managed_by_atmosphere &&
       actual['appliance_type_id'] == expected.appliance_type_id &&
-      actual['architecture'] == expected.architecture.to_s &&
-      expected.tenants.pluck(:id).include?(actual['compute_site_id'])
+      actual['architecture'] == expected.architecture.to_s
   end
 end
 


### PR DESCRIPTION
Restricts visibility of VMTs and Tenants in controllers to those which the current user is authorized to access (through Funds). Added a loophole for admins to enable them to see all VMTs.