### PR TITLE
Flavor prices

### DIFF
--- a/app/services/atmosphere/flavor_updater.rb
+++ b/app/services/atmosphere/flavor_updater.rb
@@ -1,7 +1,7 @@
 # Populate the Atmosphere database with information regarding the
 # available virtual machine flavors for each compute site.
 module Atmosphere
-  class FlavorManager
+  class FlavorUpdater
     def initialize(tenant)
       @tenant = tenant
     end

--- a/app/services/atmosphere/flavor_updater.rb
+++ b/app/services/atmosphere/flavor_updater.rb
@@ -41,6 +41,7 @@ module Atmosphere
           flavor.memory = cloud_flavor.ram
           flavor.hdd = cloud_flavor.disk
           flavor.supported_architectures = cloud_flavor.supported_architectures
+          calculate_price(flavor)
 
           unless flavor.save
             Rails.logger.error(I18n.t('virtual_machine_flavor.update_failed',
@@ -49,5 +50,7 @@ module Atmosphere
           end
         end
     end
+
+    include Atmosphere::FlavorUpdaterExt
   end
 end

--- a/app/services/atmosphere/flavor_updater.rb
+++ b/app/services/atmosphere/flavor_updater.rb
@@ -9,7 +9,7 @@ module Atmosphere
     def execute
       update_existing_flavors
       purge_non_existing_flavors
-    rescue Exception => e
+    rescue StandardError => e
       Rails.logger.error(I18n.t('virtual_machine_flavor.update_flavors_failed',
                                 id: tenant.tenant_id, msg: e.message))
     end

--- a/app/services/atmosphere/flavor_updater_ext.rb
+++ b/app/services/atmosphere/flavor_updater_ext.rb
@@ -1,0 +1,14 @@
+module Atmosphere
+  module FlavorUpdaterExt
+    extend ActiveSupport::Concern
+
+    # By default do nothing. It can be extendend in target project and create
+    # additional objects (`FlavorOsFamily`) with concreate prices. Please don't
+    # save flavor or other created objects, since it will be done at the end of
+    # flavor update operation.
+    #
+    # Flavor `cpu`, `memory` and `hdd` attributes are already set.
+    def calculate_price(_flavor)
+    end
+  end
+end

--- a/app/workers/atmosphere/flavor_worker.rb
+++ b/app/workers/atmosphere/flavor_worker.rb
@@ -5,10 +5,12 @@ module Atmosphere
     sidekiq_options queue: :monitoring
     sidekiq_options retry: false
 
-    def perform
+    def perform(tenant_id)
       begin
-        Rails.logger.debug "Updating flavor info for all tenants."
-        FlavorManager::scan_all_tenants
+        if tenant = Atmosphere::Tenant.find_by(id: tenant_id)
+          Rails.logger.debug "Updating flavor for #{tenant_id} tenant."
+          FlavorManager.new(tenant).execute
+        end
       end
     end
   end

--- a/app/workers/atmosphere/flavor_worker.rb
+++ b/app/workers/atmosphere/flavor_worker.rb
@@ -9,7 +9,7 @@ module Atmosphere
       begin
         if tenant = Atmosphere::Tenant.find_by(id: tenant_id)
           Rails.logger.debug "Updating flavor for #{tenant_id} tenant."
-          FlavorManager.new(tenant).execute
+          FlavorUpdater.new(tenant).execute
         end
       end
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -143,6 +143,8 @@ en:
       %{os_family} cost was not removed as there are running VMs that are
       billed by this figure. If you want to set them as free of charge, please
       set the fund value at 0.
+    update_flavors_failed: "Unable to update flavors for tenant %{id}: %{msg}. Skipping."
+    update_failed: "Unable to save flavor with name %{name}: nested exception is %{errors}"
   flavor_os_family:
     long_title: Virtual Machine Flavors and Pricing
     hourly_cost: Hourly cost

--- a/lib/atmosphere/clockwork.rb
+++ b/lib/atmosphere/clockwork.rb
@@ -18,7 +18,8 @@ module Atmopshere
       end
 
       every(Atmosphere.monitoring.intervals.flavor, 'monitoring.flavors') do
-        Atmosphere::FlavorWorker.perform_async
+        action_on_active_tenants('flavor monitoring',
+                                 Atmosphere::FlavorWorker)
       end
 
       every(60.minutes, 'billing.bill') do

--- a/spec/services/atmosphere/flavor_manager_spec.rb
+++ b/spec/services/atmosphere/flavor_manager_spec.rb
@@ -24,12 +24,12 @@ describe Atmosphere::FlavorManager do
 
       it 'registers tenants with flavors' do
         expect(t1.virtual_machine_flavors.count).to eq 2
-        Atmosphere::FlavorManager::scan_tenant(t1)
+        Atmosphere::FlavorManager.new(t1).execute
         expect(t1.virtual_machine_flavors.count).to eq t1.cloud_client.flavors.count
       end
 
       it 'updates existing flavour on openstack' do
-        Atmosphere::FlavorManager::scan_tenant(t1)
+        Atmosphere::FlavorManager.new(t1).execute
         fog_flavor = t1.cloud_client.flavors.detect { |f| f.id == flavor6_ost.id_at_site }
 
         flavor6_ost.reload
@@ -37,7 +37,7 @@ describe Atmosphere::FlavorManager do
       end
 
       it 'updates existing flavour on aws' do
-        Atmosphere::FlavorManager::scan_tenant(t2)
+        Atmosphere::FlavorManager.new(t2).execute
         fog_flavor = t2.cloud_client.flavors.detect { |f| f.id == flavor6_aws.id_at_site }
 
         flavor6_aws.reload
@@ -45,38 +45,37 @@ describe Atmosphere::FlavorManager do
       end
 
       it 'removes nonexistent flavor on openstack' do
-        Atmosphere::FlavorManager::scan_tenant(t1)
+        Atmosphere::FlavorManager.new(t1).execute
         expect(t1.virtual_machine_flavors.count).to eq t1.cloud_client.flavors.count
         # Add nonexistent flavor to tenant t1
         create(:virtual_machine_flavor, tenant: t1, id_at_site: 'foo', flavor_name: 'baz')
         t1.reload
         expect(t1.virtual_machine_flavors.where(flavor_name: 'baz').count).to eq 1
         # Scan tenant again and expect flavor "baz" to be gone
-        Atmosphere::FlavorManager::scan_tenant(t1)
+        Atmosphere::FlavorManager.new(t1).execute
         t1.reload
         expect(t1.virtual_machine_flavors.where(flavor_name: 'baz').count).to eq 0
       end
-
     end
 
     context 'when idle' do
       it 'scans openstack tenant' do
         # Fog creates 7 mock flavors by default
-        Atmosphere::FlavorManager::scan_tenant(t1)
+        Atmosphere::FlavorManager.new(t1).execute
         expect(t1.virtual_machine_flavors.count).to eq t1.cloud_client.flavors.count
 
         # No further changes expected
-        Atmosphere::FlavorManager::scan_tenant(t1)
+        Atmosphere::FlavorManager.new(t1).execute
         expect(t1.virtual_machine_flavors.count).to eq t1.cloud_client.flavors.count
       end
 
       it 'scans AWS tenant' do
         # Fog creates 7 mock flavors by default
-        Atmosphere::FlavorManager::scan_tenant(t2)
+        Atmosphere::FlavorManager.new(t2).execute
         expect(t2.virtual_machine_flavors.count).to eq t2.cloud_client.flavors.count
 
         # No further changes expected
-        Atmosphere::FlavorManager::scan_tenant(t2)
+        Atmosphere::FlavorManager.new(t2).execute
         expect(t2.virtual_machine_flavors.count).to eq t2.cloud_client.flavors.count
       end
     end

--- a/spec/services/atmosphere/flavor_updater_spec.rb
+++ b/spec/services/atmosphere/flavor_updater_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require 'fog/openstack'
 
-describe Atmosphere::FlavorManager do
+describe Atmosphere::FlavorUpdater do
 
   let(:t1) { create(:openstack_tenant) }
   let(:t2) { create(:amazon_tenant) }
@@ -24,12 +24,12 @@ describe Atmosphere::FlavorManager do
 
       it 'registers tenants with flavors' do
         expect(t1.virtual_machine_flavors.count).to eq 2
-        Atmosphere::FlavorManager.new(t1).execute
+        Atmosphere::FlavorUpdater.new(t1).execute
         expect(t1.virtual_machine_flavors.count).to eq t1.cloud_client.flavors.count
       end
 
       it 'updates existing flavour on openstack' do
-        Atmosphere::FlavorManager.new(t1).execute
+        Atmosphere::FlavorUpdater.new(t1).execute
         fog_flavor = t1.cloud_client.flavors.detect { |f| f.id == flavor6_ost.id_at_site }
 
         flavor6_ost.reload
@@ -37,7 +37,7 @@ describe Atmosphere::FlavorManager do
       end
 
       it 'updates existing flavour on aws' do
-        Atmosphere::FlavorManager.new(t2).execute
+        Atmosphere::FlavorUpdater.new(t2).execute
         fog_flavor = t2.cloud_client.flavors.detect { |f| f.id == flavor6_aws.id_at_site }
 
         flavor6_aws.reload
@@ -45,14 +45,14 @@ describe Atmosphere::FlavorManager do
       end
 
       it 'removes nonexistent flavor on openstack' do
-        Atmosphere::FlavorManager.new(t1).execute
+        Atmosphere::FlavorUpdater.new(t1).execute
         expect(t1.virtual_machine_flavors.count).to eq t1.cloud_client.flavors.count
         # Add nonexistent flavor to tenant t1
         create(:virtual_machine_flavor, tenant: t1, id_at_site: 'foo', flavor_name: 'baz')
         t1.reload
         expect(t1.virtual_machine_flavors.where(flavor_name: 'baz').count).to eq 1
         # Scan tenant again and expect flavor "baz" to be gone
-        Atmosphere::FlavorManager.new(t1).execute
+        Atmosphere::FlavorUpdater.new(t1).execute
         t1.reload
         expect(t1.virtual_machine_flavors.where(flavor_name: 'baz').count).to eq 0
       end
@@ -61,21 +61,21 @@ describe Atmosphere::FlavorManager do
     context 'when idle' do
       it 'scans openstack tenant' do
         # Fog creates 7 mock flavors by default
-        Atmosphere::FlavorManager.new(t1).execute
+        Atmosphere::FlavorUpdater.new(t1).execute
         expect(t1.virtual_machine_flavors.count).to eq t1.cloud_client.flavors.count
 
         # No further changes expected
-        Atmosphere::FlavorManager.new(t1).execute
+        Atmosphere::FlavorUpdater.new(t1).execute
         expect(t1.virtual_machine_flavors.count).to eq t1.cloud_client.flavors.count
       end
 
       it 'scans AWS tenant' do
         # Fog creates 7 mock flavors by default
-        Atmosphere::FlavorManager.new(t2).execute
+        Atmosphere::FlavorUpdater.new(t2).execute
         expect(t2.virtual_machine_flavors.count).to eq t2.cloud_client.flavors.count
 
         # No further changes expected
-        Atmosphere::FlavorManager.new(t2).execute
+        Atmosphere::FlavorUpdater.new(t2).execute
         expect(t2.virtual_machine_flavors.count).to eq t2.cloud_client.flavors.count
       end
     end


### PR DESCRIPTION
Flavor cost can be calculated by extended project by implementing `Atmosphere::FlavorUpdaterExt#calculate_price(flavor)` method. To allow such a case following actions were needed (and are implemented in this PR):

 - static methods were removed
 - `Atmosphere::FlavorUpdaterExt` were added