### PR TITLE
Move optimize appliance into service from callback

### DIFF
--- a/app/controllers/atmosphere/api/v1/appliance_sets_controller.rb
+++ b/app/controllers/atmosphere/api/v1/appliance_sets_controller.rb
@@ -79,6 +79,7 @@ module Atmosphere
             appl_params[:appliance_set_id] = @appliance_set.id
             creator = ApplianceCreator.new(appl_params, delegate_auth)
             appl = creator.build
+            Atmosphere::CreateApplianceService.new(appl).execute
             @appliance_set.appliances << appl
           end
         end

--- a/app/controllers/atmosphere/api/v1/appliances_controller.rb
+++ b/app/controllers/atmosphere/api/v1/appliances_controller.rb
@@ -19,8 +19,11 @@ class Atmosphere::Api::V1::AppliancesController < Atmosphere::Api::ApplicationCo
   end
 
   def create
-    @appliance.save!
-    render json: @appliance, status: :created
+    if Atmosphere::CreateApplianceService.new(@appliance).execute
+      render json: @appliance, status: :created
+    else
+      render_error @appliance
+    end
   end
 
   def update

--- a/app/models/atmosphere/appliance.rb
+++ b/app/models/atmosphere/appliance.rb
@@ -62,7 +62,6 @@ module Atmosphere
     before_create :create_dev_mode_property_set, if: :development?
     before_save :assign_fund, if: 'fund.nil?'
     after_destroy :remove_appliance_configuration_instance_if_needed
-    after_create :optimize_saved_appliance
 
     scope :started_on_site, ->(tenant) do
       joins(:virtual_machines).
@@ -174,14 +173,6 @@ module Atmosphere
          appliance_configuration_instance.appliances.blank?
         appliance_configuration_instance.destroy
       end
-    end
-
-    def optimize_saved_appliance
-      optimizer.run(created_appliance: self)
-    end
-
-    def optimizer
-      Optimizer.instance
     end
   end
 end

--- a/app/services/atmosphere/create_appliance_service.rb
+++ b/app/services/atmosphere/create_appliance_service.rb
@@ -1,0 +1,20 @@
+module Atmosphere
+  #
+  # Save appliance in DB and trigger appliance optimization.
+  #
+  class CreateApplianceService
+    def initialize(appliance)
+      @appliance = appliance
+    end
+
+    def execute
+      appliance.save.tap do |success|
+        Atmosphere::Cloud::SatisfyAppliance.new(appliance).execute if success
+      end
+    end
+
+    private
+
+    attr_reader :appliance
+  end
+end

--- a/spec/models/atmosphere/action_spec.rb
+++ b/spec/models/atmosphere/action_spec.rb
@@ -1,15 +1,6 @@
 require 'rails_helper'
 
 describe Atmosphere::Action do
-  let(:optimizer) { double('optimizer') }
-
-  before do
-    expect(Atmosphere::Optimizer).
-      to receive(:instance).at_least(:once) { optimizer }
-
-    expect(optimizer).to receive(:run).at_least(:once).with(anything)
-  end
-
   let(:appl) { create(:appliance) }
   subject { Atmosphere::Action.create(appliance: appl) }
 

--- a/spec/models/atmosphere/appliance_spec.rb
+++ b/spec/models/atmosphere/appliance_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 describe Atmosphere::Appliance do
-  let(:optimizer) { double }
-
   it { should belong_to :appliance_set }
   it { should validate_presence_of :appliance_set }
   it { should validate_presence_of :state }
@@ -50,10 +48,6 @@ describe Atmosphere::Appliance do
   end
 
   context 'appliance configuration instances management' do
-    before do
-      allow(Atmosphere::Optimizer).to receive(:instance).and_return(optimizer)
-      allow(optimizer).to receive(:run)
-    end
     let!(:appliance) { create(:appliance) }
 
     it 'removes configuration instance with the last Appliance using it' do

--- a/spec/requests/atmosphere/api/actions_spec.rb
+++ b/spec/requests/atmosphere/api/actions_spec.rb
@@ -12,15 +12,6 @@ describe Atmosphere::Api::V1::ActionsController do
     end
 
     context 'when authenticated' do
-      let(:optimizer) { double('optimizer') }
-
-      before do
-        expect(Atmosphere::Optimizer).
-          to receive(:instance).at_least(:once) { optimizer }
-
-        expect(optimizer).to receive(:run).at_least(:once).with(anything)
-      end
-
       let!(:message) { 'message123' }
 
       let!(:user) { create(:user) }

--- a/spec/requests/atmosphere/api/appliance_sets_spec.rb
+++ b/spec/requests/atmosphere/api/appliance_sets_spec.rb
@@ -4,7 +4,8 @@ describe Atmosphere::Api::V1::ApplianceSetsController do
   include ApiHelpers
 
   before do
-    allow(Atmosphere::Optimizer.instance).to receive(:run)
+    allow(Atmosphere::Cloud::SatisfyAppliance).
+      to receive(:new).and_return(double(execute: true))
   end
 
   let(:user) { create(:developer) }
@@ -178,8 +179,8 @@ describe Atmosphere::Api::V1::ApplianceSetsController do
         end
 
         it 'calls optimizer for each appliance of created AS' do
-          expect(Atmosphere::Optimizer.instance).
-            to have_received(:run).
+          expect(Atmosphere::Cloud::SatisfyAppliance).
+            to have_received(:new).
             exactly(created_as.appliances.count).times
         end
 

--- a/spec/services/atmosphere/cloud/scale_appliance_spec.rb
+++ b/spec/services/atmosphere/cloud/scale_appliance_spec.rb
@@ -8,7 +8,6 @@ describe Atmosphere::Cloud::ScaleAppliance do
   before do
     allow(Atmosphere::ApplianceVmsManager).
       to receive(:new).and_return(appl_vm_manager)
-    expect(appl_vm_manager).to receive(:save)
     allow(appliance).to receive(:optimization_strategy) { strategy }
   end
 


### PR DESCRIPTION
This is a first step to make optimization asynchronous. Optimization execution was removed from appliance callback and moved into dedicated service.