### PR TITLE
Travis builds use container infrastructure + bundle cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 sudo: false
 
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+sudo: false
 
 rvm:
   - 2.2.1


### PR DESCRIPTION
Travis introduced container infrastructure. It is faster and more resources are available there. What is more builds can be even faster by caching bundler gem fetch.