### PR TITLE
Use tenant_id when site_id is nil

### DIFF
--- a/app/models/atmosphere/tenant.rb
+++ b/app/models/atmosphere/tenant.rb
@@ -181,6 +181,10 @@ module Atmosphere
         where("atmosphere_tenants.site_id = '#{site_id}'").all
     end
 
+    def site_id
+      self[:site_id] || tenant_id
+    end
+
     private
 
     def update_cloud_client

--- a/lib/support/redirus/http.conf.erb
+++ b/lib/support/redirus/http.conf.erb
@@ -1,0 +1,21 @@
+upstream <%= @name %>_http {
+<% for worker in @workers -%>
+  server <%= worker %>;
+<% end -%>
+}
+
+server {
+  listen 149.156.10.135:80;
+  server_name <%= @name %>.FIXME;
+  server_tokens off;
+  proxy_set_header X-Server-Address $scheme://<%= name %>.FIXME;
+  proxy_set_header Host $http_host;
+
+  location / {
+    proxy_http_version 1.1;
+    proxy_pass http://<%= @name %>_http;
+<% for property in @location_properties -%>
+    <%= property %>;
+<% end -%>
+  }
+}

--- a/lib/support/redirus/https.conf.erb
+++ b/lib/support/redirus/https.conf.erb
@@ -1,0 +1,26 @@
+upstream <%= @name %>_https {
+<% for worker in @workers -%>
+  server <%= worker %>;
+<% end -%>
+}
+
+server {
+  listen *:443 ssl;
+  server_name <%= @name %>.FIXME;
+
+  ssl_certificate     /path/to/host.pem;
+  ssl_certificate_key /path/to/host.key;
+  ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
+
+  server_tokens off;
+  proxy_set_header X-Server-Address $scheme://<%= name %>.FIXME;
+  proxy_set_header Host $http_host;
+
+  location / {
+    proxy_http_version 1.1;
+    proxy_pass https://<%= @name %>_https;
+<% for property in @location_properties -%>
+    <%= property %>;
+<% end -%>
+  }
+}

--- a/spec/models/atmosphere/tenant_spec.rb
+++ b/spec/models/atmosphere/tenant_spec.rb
@@ -265,4 +265,18 @@ describe Atmosphere::Tenant do
         to match_array [@t, t2]
     end
   end
+
+  describe '#site_id' do
+    it 'uses tenant_id value when site_id not set' do
+      t = build(:tenant, tenant_id: 'my_tenant', site_id: nil)
+
+      expect(t.site_id).to eq 'my_tenant'
+    end
+
+    it 'uses site_id if set' do
+      t = build(:tenant, tenant_id: 'my_tenant', site_id: 'my_site')
+
+      expect(t.site_id).to eq 'my_site'
+    end
+  end
 end


### PR DESCRIPTION
This change guarantees backward compatibility. `site_id` is used to get
correct queue name while generating job to add/remove http/https
redirection. Previously `tenant_id` was used for it. This change
guarantee backward compatibility and allow to override queue using
`site_id` field.

Fix #237 

@dice-cyfronet/atmo-dev-team please take a look.