### PR TITLE
Fix delete vm vmt

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,7 +163,7 @@ GEM
     enumerize (0.11.0)
       activesupport (>= 3.2)
     erubis (2.7.0)
-    excon (0.45.3)
+    excon (0.45.4)
     execjs (2.5.2)
     extlib (0.9.16)
     factory_girl (4.5.0)
@@ -177,11 +177,12 @@ GEM
     ffi (1.9.10)
     fission (0.5.0)
       CFPropertyList (~> 2.2)
-    fog (1.32.0)
+    fog (1.33.0)
       fog-atmos
       fog-aws (>= 0.6.0)
       fog-brightbox (~> 0.4)
       fog-core (~> 1.32)
+      fog-dynect
       fog-ecloud (= 0.1.1)
       fog-google (>= 0.0.2)
       fog-json
@@ -203,7 +204,7 @@ GEM
     fog-atmos (0.1.0)
       fog-core
       fog-xml
-    fog-aws (0.7.2)
+    fog-aws (0.7.4)
       fog-core (~> 1.27)
       fog-json (~> 1.0)
       fog-xml (~> 0.1)
@@ -212,17 +213,21 @@ GEM
       fog-core (~> 1.27)
       fog-json (~> 1.0)
       fog-xml (~> 0.1)
-    fog-brightbox (0.7.2)
+    fog-brightbox (0.9.0)
       fog-core (~> 1.22)
       fog-json
       inflecto (~> 0.0.2)
-    fog-core (1.32.0)
+    fog-core (1.32.1)
       builder
       excon (~> 0.45)
       formatador (~> 0.2)
       mime-types
       net-scp (~> 1.1)
       net-ssh (>= 2.1.3)
+    fog-dynect (0.0.1)
+      fog-core
+      fog-json
+      fog-xml
     fog-ecloud (0.1.1)
       fog-core
       fog-xml
@@ -239,7 +244,7 @@ GEM
       fog-core (~> 1.27)
       fog-json (~> 1.0)
       fog-xml (~> 0.1)
-    fog-profitbricks (0.0.3)
+    fog-profitbricks (0.0.5)
       fog-core
       fog-xml
       nokogiri

--- a/config/initializers/unify_openstack.rb
+++ b/config/initializers/unify_openstack.rb
@@ -40,9 +40,7 @@ end
 
 class Fog::Compute::OpenStack::Servers
   def destroy(id_at_site)
-    vm = get(id_at_site)
-
-    !vm || vm.destroy
+    service.delete_server(id_at_site)
   end
 end
 
@@ -63,5 +61,11 @@ class Fog::Compute::OpenStack::Image
 
   def tags
     metadata.to_hash
+  end
+end
+
+class Fog::Compute::OpenStack::Images
+  def destroy(id_at_site)
+    service.delete_image(id_at_site)
   end
 end


### PR DESCRIPTION
This PR restores old fog implementation, where were possible to remove server and image using `servers` and `images` model.