### PR TITLE
checking for nil values in new_v__a_f_a_t method

### DIFF
--- a/app/providers/atmosphere/optimization_strategy/manual.rb
+++ b/app/providers/atmosphere/optimization_strategy/manual.rb
@@ -18,9 +18,13 @@ module Atmosphere
       def new_vms_tmpls_and_flavors_and_tenants
         tmpls_and_flavors_and_tenants = []
         tmpls = vmt_candidates
-        appliance.optimization_policy_params['vms'].each do |vm|
+        requested_vms = appliance.try(:optimization_policy_params).
+                        try(:[], 'vms') || []
+        requested_vms.each do |vm|
           options = { cpu: vm['cpu'], memory: vm['mem'] }
-          tmpls_and_flavors_and_tenants += Default.select_tmpls_and_flavors_and_tenants(tmpls, @appliance, options)
+          tmpls_and_flavors_and_tenants +=
+            Default.
+            select_tmpls_and_flavors_and_tenants(tmpls, @appliance, options)
         end
         tmpls_and_flavors_and_tenants
       end

--- a/spec/providers/atmosphere/optimization_strategy/manual_spec.rb
+++ b/spec/providers/atmosphere/optimization_strategy/manual_spec.rb
@@ -88,4 +88,31 @@ describe Atmosphere::OptimizationStrategy::Manual do
     expect(vm_candidates.count).to eq 1
     expect(vm_candidates.first.tenants.first).to eq t
   end
+
+  context 'appliance optimization policy params is nil' do
+    it 'does not fail' do
+      appl = build(:appliance, optimization_policy_params: nil)
+      manual_strategy = Atmosphere::OptimizationStrategy::Manual.new(appl)
+      manual_strategy.new_vms_tmpls_and_flavors_and_tenants
+    end
+
+    it 'returns empty array' do
+      appl = build(:appliance, optimization_policy_params: nil)
+      manual_strategy = Atmosphere::OptimizationStrategy::Manual.new(appl)
+      expect(manual_strategy.new_vms_tmpls_and_flavors_and_tenants).to be_empty
+    end
+  end
+  context 'vms parameter is nil' do
+    it 'does not fail' do
+      appl = build(:appliance, optimization_policy_params: { vms: nil })
+      manual_strategy = Atmosphere::OptimizationStrategy::Manual.new(appl)
+      manual_strategy.new_vms_tmpls_and_flavors_and_tenants
+    end
+
+    it 'returns empty array' do
+      appl = build(:appliance, optimization_policy_params: { vms: nil })
+      manual_strategy = Atmosphere::OptimizationStrategy::Manual.new(appl)
+      expect(manual_strategy.new_vms_tmpls_and_flavors_and_tenants).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
https://github.com/dice-cyfronet/atmosphere/issues/75

If used to fail if optimization_strategy_params or optimization_strategy_params['vms']
were nil.