### PR TITLE
Don't allow to change PMT, PMP, endpoint assignment on update

### DIFF
--- a/app/controllers/atmosphere/api/v1/endpoints_controller.rb
+++ b/app/controllers/atmosphere/api/v1/endpoints_controller.rb
@@ -22,7 +22,7 @@ class Atmosphere::Api::V1::EndpointsController < Atmosphere::Api::ApplicationCon
   end
 
   def update
-    @endpoint.update_attributes!(endpoint_params)
+    @endpoint.update_attributes!(endpoint_update_params)
     render json: @endpoint
   end
 
@@ -51,6 +51,12 @@ class Atmosphere::Api::V1::EndpointsController < Atmosphere::Api::ApplicationCon
 
   def endpoint_params
     params.require(:endpoint).permit(:name, :endpoint_type, :description, :descriptor, :invocation_path, :port_mapping_template_id, :secured)
+  end
+
+  def endpoint_update_params
+    params.require(:endpoint).
+      permit(:name, :endpoint_type, :description, :descriptor,
+             :invocation_path, :secured)
   end
 
   def model_class

--- a/app/controllers/atmosphere/api/v1/port_mapping_properties_controller.rb
+++ b/app/controllers/atmosphere/api/v1/port_mapping_properties_controller.rb
@@ -31,7 +31,7 @@ module Atmosphere
         end
 
         def update
-          @manager.update!(port_mapping_property_params)
+          @manager.update!(port_mapping_property_update_params)
 
           render json: @manager.object,
                  serializer: PortMappingPropertySerializer
@@ -51,6 +51,15 @@ module Atmosphere
           params.
             require(:port_mapping_property).
             permit(:key, :value, :port_mapping_template_id, :compute_site_id).
+            tap do |p|
+              p[:tenant_id] = p.delete(:compute_site_id)
+            end
+        end
+
+        def port_mapping_property_update_params
+          params.
+            require(:port_mapping_property).
+            permit(:key, :value, :compute_site_id).
             tap do |p|
               p[:tenant_id] = p.delete(:compute_site_id)
             end

--- a/app/controllers/atmosphere/api/v1/port_mapping_templates_controller.rb
+++ b/app/controllers/atmosphere/api/v1/port_mapping_templates_controller.rb
@@ -28,8 +28,7 @@ class Atmosphere::Api::V1::PortMappingTemplatesController < Atmosphere::Api::App
   end
 
   def update
-    update_params = port_mapping_template_params
-    @manager.update!(update_params)
+    @manager.update!(port_mapping_template_update_params)
     render json: @manager.object
   end
 
@@ -58,6 +57,12 @@ class Atmosphere::Api::V1::PortMappingTemplatesController < Atmosphere::Api::App
   def port_mapping_template_params
     params.require(:port_mapping_template).permit(
         :service_name, :target_port, :transport_protocol, :application_protocol, :appliance_type_id, :dev_mode_property_set_id)
+  end
+
+  def port_mapping_template_update_params
+    params.require(:port_mapping_template).
+      permit(:service_name, :target_port,
+             :transport_protocol, :application_protocol)
   end
 
   def initialize_manager

--- a/doc/api/endpoints.md
+++ b/doc/api/endpoints.md
@@ -63,9 +63,9 @@ Parameters:
 
 + `port_mapping_template_id` (required) - The ID of the Port Mapping Template which should acquire the new Endpoint
 + `name` (required) - Short name of the endpoint meaning and purpose
-+ `description` (optional) - Textual, human-readable description what is available on that port
-+ `descriptor` (optional) - Machine-readable document that describes the service available on that port. It supports one dynamic parameter: `#{descriptor_url}`. When it is included in descriptor payload than it will be changed into actual endpoint url.
-+ `endpoint_type` (required) - One of "rest", "ws" or "webapp"
++ `description` (optional) - Textual, human-readable description what is available on the given port
++ `descriptor` (optional) - Machine-readable document that describes the service available on the given port. It supports one dynamic parameter: `#{descriptor_url}`. When included in descriptor payload, this parameter will be automatically swapped for the actual endpoint URL.
++ `endpoint_type` (optional) - Choose "rest", "ws" or "webapp"
 + `invocation_path` (required) - Application invocation path
 + `secured` (optional) - True if endpoint is secured and require user token (default `false`)
 
@@ -85,11 +85,11 @@ Parameters:
 
 + `id` (required) - The ID of the Endpoint to be updated
 + `name` (optional) - Short name of the endpoint meaning and purpose
-+ `description` (optional) - Textual, human-readable description what is available on that port
-+ `descriptor` (optional) - Machine-readable document that describes the service available on that port. It supports one dynamic parameter: `#{descriptor_url}`. When it is included in descriptor payload than it will be changed into actual endpoint url.
-+ `endpoint_type` (optional) - One of "rest", "ws" or "webapp"
++ `description` (optional) - Textual, human-readable description of what is available on the given port
++ `descriptor` (optional) - Machine-readable document that describes the service available on the given port. It supports one dynamic parameter: `#{descriptor_url}`. When included in descriptor payload, this parameter will be automatically swapped for the actual endpoint URL.
++ `endpoint_type` (optional) - Choose "rest", "ws" or "webapp"
 + `invocation_path` (optional) - Application invocation path
-+ `secured` (optional) - True if endpoint is secured and require user token (default `false`)
++ `secured` (optional) - True if endpoint is secured and requires user token (default `false`)
 
 When a parameter is omitted, the value would be retained from the older version of the entity.
 

--- a/doc/api/endpoints.md
+++ b/doc/api/endpoints.md
@@ -84,7 +84,12 @@ PUT /endpoints/:id
 Parameters:
 
 + `id` (required) - The ID of the Endpoint to be updated
-+ All other parameters are optional and are the same as for the `POST` creation method
++ `name` (optional) - Short name of the endpoint meaning and purpose
++ `description` (optional) - Textual, human-readable description what is available on that port
++ `descriptor` (optional) - Machine-readable document that describes the service available on that port. It supports one dynamic parameter: `#{descriptor_url}`. When it is included in descriptor payload than it will be changed into actual endpoint url.
++ `endpoint_type` (optional) - One of "rest", "ws" or "webapp"
++ `invocation_path` (optional) - Application invocation path
++ `secured` (optional) - True if endpoint is secured and require user token (default `false`)
 
 When a parameter is omitted, the value would be retained from the older version of the entity.
 

--- a/doc/api/port_mapping_properties.md
+++ b/doc/api/port_mapping_properties.md
@@ -81,7 +81,7 @@ PUT /port_mapping_properties/:id
 Parameters:
 
 + `id` (required) - The ID of the Port Mapping Property to be updated
-+ `key` (required) - The exact key string, which will be recognized by property setting Atmosphere mechanism
++ `key` (required) - The exact key string which will be recognized by the property-setting Atmosphere mechanism
 + `value` (optional) - The exact value to which the property key should be set
 
 When a parameter is omitted, the value would be retained from the older version of the entity.

--- a/doc/api/port_mapping_properties.md
+++ b/doc/api/port_mapping_properties.md
@@ -81,7 +81,8 @@ PUT /port_mapping_properties/:id
 Parameters:
 
 + `id` (required) - The ID of the Port Mapping Property to be updated
-+ All other parameters are optional and are the same as for the `POST` creation method
++ `key` (required) - The exact key string, which will be recognized by property setting Atmosphere mechanism
++ `value` (optional) - The exact value to which the property key should be set
 
 When a parameter is omitted, the value would be retained from the older version of the entity.
 

--- a/doc/api/port_mapping_templates.md
+++ b/doc/api/port_mapping_templates.md
@@ -71,10 +71,10 @@ Parameters (one of the first two is required):
 
 + `appliance_type_id` - The ID of the Appliance Type which should acquire the new port mapping template
 + `dev_mode_property_set_id` - The ID of the Dev Mode Property Set which should acquire the new port mapping template
-+ `transport_protocol` (required) - What transport protocol the port operates, the value should be either "tcp" or "udp"
-+ `application_protocol` (required) - If using TCP transport protocol, choose one of "http", "https", "none". Use "none" for UDP
-+ `service_name` (required) - Some kind of descriptive name for the service operating on that port
-+ `target_port` (required) - The port number
++ `transport_protocol` (required) - The transport protocol operated by the given port. The value should be either "tcp" or "udp".
++ `application_protocol` (required) - When using the TCP transport protocol, choose "http", "https" or "none". Use "none" for UDP connections.
++ `service_name` (required) - Descriptive name of the service operating at the given port
++ `target_port` (required) - Port number
 
 In case of successful Port Mapping Template creation, returns the JSON object with the details of the created entity.
 
@@ -91,10 +91,10 @@ PUT /port_mapping_templates/:id
 Parameters:
 
 + `id` (required) - The ID of the Port Mapping Template to be updated
-+ `transport_protocol` (required) - What transport protocol the port operates, the value should be either "tcp" or "udp"
-+ `application_protocol` (required) - If using TCP transport protocol, choose one of "http", "https", "none". Use "none" for UDP
-+ `service_name` (required) - Some kind of descriptive name for the service operating on that port
-+ `target_port` (required) - The port number
++ `transport_protocol` (required) - The transport protocol operated by the given port. The value should be either "tcp" or "udp".
++ `application_protocol` (required) - When using the TCP transport protocol, choose "http", "https" or "none". Use "none" for UDP connections.
++ `service_name` (required) - Descriptive name of the service operating at the given port
++ `target_port` (required) - Port number
 
 When a parameter is omitted, the value would be retained from the older version of the entity. However, keep in mind
 the application and transport protocol constraints when updating these values.

--- a/doc/api/port_mapping_templates.md
+++ b/doc/api/port_mapping_templates.md
@@ -91,7 +91,10 @@ PUT /port_mapping_templates/:id
 Parameters:
 
 + `id` (required) - The ID of the Port Mapping Template to be updated
-+ All other parameters are optional and are the same as for the `POST` creation method
++ `transport_protocol` (required) - What transport protocol the port operates, the value should be either "tcp" or "udp"
++ `application_protocol` (required) - If using TCP transport protocol, choose one of "http", "https", "none". Use "none" for UDP
++ `service_name` (required) - Some kind of descriptive name for the service operating on that port
++ `target_port` (required) - The port number
 
 When a parameter is omitted, the value would be retained from the older version of the entity. However, keep in mind
 the application and transport protocol constraints when updating these values.

--- a/spec/requests/atmosphere/api/endpoints_spec.rb
+++ b/spec/requests/atmosphere/api/endpoints_spec.rb
@@ -320,6 +320,14 @@ describe Atmosphere::Api::V1::EndpointsController do
         expect(updated_e['port_mapping_template_id']).to eq old_port_mapping_template_id
       end
 
+      it 'is unable to change assigment to PMT' do
+        put api("/endpoints/#{e1.id}", user),
+            endpoint: { port_mapping_template_id: pmt2.id }
+        e1.reload
+
+        expect(e1.port_mapping_template).to eq pmt1
+      end
+
       it 'admin is able to update any endpoint' do
         put api("/endpoints/#{e1.id}", admin), update_json
         expect(response.status).to eq 200

--- a/spec/requests/atmosphere/api/port_mapping_properties_spec.rb
+++ b/spec/requests/atmosphere/api/port_mapping_properties_spec.rb
@@ -240,6 +240,14 @@ describe Atmosphere::Api::V1::PortMappingPropertiesController do
         expect(updated_e['port_mapping_template_id']).to eq old_port_mapping_template_id
       end
 
+      it 'is not able to update PMT' do
+        put api("/port_mapping_properties/#{pmp1.id}", user),
+            port_mapping_property: { port_mapping_template_id: pmt2.id }
+        pmp1.reload
+
+        expect(pmp1.port_mapping_template).to eq pmt1
+      end
+
       it 'admin is able to update any port mapping property' do
         put api("/port_mapping_properties/#{pmp1.id}", admin), update_json
         expect(response.status).to eq 200

--- a/spec/requests/atmosphere/api/port_mapping_templates_spec.rb
+++ b/spec/requests/atmosphere/api/port_mapping_templates_spec.rb
@@ -314,6 +314,25 @@ describe Atmosphere::Api::V1::PortMappingTemplatesController do
         put api("port_mapping_templates/wrong_id", user), update_json
         expect(response.status).to eq 404
       end
+
+      it 'does not allow to change assigment into AT' do
+        put api("/port_mapping_templates/#{pmt1.id}", user),
+            port_mapping_template: { appliance_type_id: at2.id }
+        pmt1.reload
+
+        expect(pmt1.appliance_type).to eq at1
+      end
+
+      it 'does not allow to change assigment into DMPS' do
+        appl2 = create(:appliance, appliance_set: as)
+        put api("/port_mapping_templates/#{pmt3.id}", user),
+            port_mapping_template: {
+              dev_mode_property_set_id: appl2.dev_mode_property_set.id
+            }
+        pmt3.reload
+
+        expect(pmt3.dev_mode_property_set).to eq appl1.dev_mode_property_set
+      end
     end
 
     context 'when authenticated as admin' do


### PR DESCRIPTION
User will not be able to change assignment between
  * `port mapping template` and `appliance type` or `dev mode property set`
  * `port mapping property` and `port mapping template`
  * `endpoint` and `port mapping template`
during update (`PUT`) operation. This MR fixes 2 first issues discovered by security audit.

@dice-cyfronet/atmo-dev-team please take a look