### PR TITLE
enhanced fingerprint generation

### DIFF
--- a/app/models/atmosphere/user_key.rb
+++ b/app/models/atmosphere/user_key.rb
@@ -52,10 +52,10 @@ module Atmosphere
         file.puts(public_key)
         file.rewind
         output = nil
-        IO.popen("ssh-keygen -lf #{file.path}") {|out|
+        IO.popen(['ssh-keygen', '-lf', file.path]) do |out|
           output = out.read
           logger.info "Output #{output}"
-        }
+        end
         if output.include? 'is not a public key file'
           logger.error "Provided public key #{public_key} is invalid"
           errors.add(:public_key, 'is invalid')


### PR DESCRIPTION
https://github.com/dice-cyfronet/atmosphere/issues/256

If filename of the public key was manipulated running ssh-keygen command could be exploited
to inject some code to shell. Current invocation of ssh-keygen is safer.

Fix #256.