### PR TITLE
Use sshkey lib to generate public key fingerprint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,7 @@ PATH
       sidekiq
       simple_form
       sinatra
+      sshkey
       turbolinks
       unf
       will_paginate (~> 3.0.5)
@@ -550,6 +551,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
+    sshkey (1.8.0)
     systemu (2.6.5)
     thor (0.19.1)
     thread_safe (0.3.5)

--- a/atmosphere.gemspec
+++ b/atmosphere.gemspec
@@ -79,6 +79,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'highcharts-rails', '~>4.0.4'
   s.add_dependency 'migratio'
   s.add_dependency 'draper', '~> 1.3'
+  s.add_dependency 'sshkey'
 
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'factory_girl_rails'

--- a/lib/atmosphere/engine.rb
+++ b/lib/atmosphere/engine.rb
@@ -26,6 +26,7 @@ require 'github-markup'
 require 'redcarpet'
 
 require 'draper'
+require 'sshkey'
 
 module Atmosphere
   class Engine < ::Rails::Engine

--- a/spec/models/atmosphere/user_key_spec.rb
+++ b/spec/models/atmosphere/user_key_spec.rb
@@ -58,7 +58,8 @@ describe Atmosphere::UserKey do
     saved = user_key.save
     expect(saved).to be_falsy
     errors = user_key.errors.messages
-    expect(errors).to eql({public_key: ["bad type of key (only ssh-rsa is allowed)", "is invalid"]})
+    expect(errors[:public_key]).
+      to include('bad type of key (only ssh-rsa is allowed)')
   end
 
   describe '#describe' do

--- a/spec/requests/atmosphere/api/user_keys_spec.rb
+++ b/spec/requests/atmosphere/api/user_keys_spec.rb
@@ -168,11 +168,8 @@ describe Atmosphere::Api::V1::UserKeysController do
         }
         post api("/user_keys", user), invalid_user_key_req
         expect(response.status).to eq 422
-        expect(json_response['details']).to eq(
-          {
-            'public_key' => ['can\'t be blank']
-          }
-        )
+        expect(json_response['details']['public_key']).
+          to include('can\'t be blank')
       end
 
       it 'returns 402 Unprocessable Entity status if invalid public key is provided' do
@@ -184,12 +181,8 @@ describe Atmosphere::Api::V1::UserKeysController do
         }
         post api("/user_keys", user), invalid_user_key_req
         expect(response.status).to eq 422
-        expect(json_response['details']).to eq({
-          'public_key' => [
-            'bad type of key (only ssh-rsa is allowed)',
-            'is invalid'
-          ]
-        })
+        expect(json_response['details']['public_key']).
+          to include('bad type of key (only ssh-rsa is allowed)')
       end
 
       it 'returns 402 Unprocessable Entity status if the request is incorrect' do


### PR DESCRIPTION
Previously system command was used. This was OS specific and e.g. on Ubuntu 15.10 this does not work. Now `sshkey` library is used which should be agnostic.