### PR TITLE
Remove VM only when it exists, do nothing otherwise

### DIFF
--- a/app/workers/atmosphere/cloud/vm_destroy_worker.rb
+++ b/app/workers/atmosphere/cloud/vm_destroy_worker.rb
@@ -7,8 +7,8 @@ module Atmosphere
       sidekiq_options retry: 4
 
       def perform(vm_id)
-        vm = Atmosphere::VirtualMachine.find(vm_id)
-        vm.destroy!
+        vm = Atmosphere::VirtualMachine.find_by(id: vm_id)
+        vm.destroy! if vm
       end
     end
   end

--- a/spec/workers/atmosphere/cloud/vm_destroy_worker_spec.rb
+++ b/spec/workers/atmosphere/cloud/vm_destroy_worker_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe Atmosphere::Cloud::VmDestroyWorker do
+  it 'destroy existing VM' do
+    vm = create(:virtual_machine)
+
+    expect { subject.perform(vm.id) }.
+      to change { Atmosphere::VirtualMachine.count }.by(-1)
+  end
+
+  it 'does nothing when VM does not exist' do
+    subject.perform('does not exist')
+  end
+end


### PR DESCRIPTION
Fixes problem with failing jobs, when trying to delete not existing VMs