### PR TITLE
Possibility to configure url checker, timeout set to 1s

### DIFF
--- a/app/workers/atmosphere/endpoint_status_check_worker.rb
+++ b/app/workers/atmosphere/endpoint_status_check_worker.rb
@@ -17,7 +17,7 @@ module Atmosphere
     private
 
     def check_mapping(mapping)
-      if @check.is_available(mapping.url)
+      if @check.is_available(mapping.url, Atmosphere.url_monitoring.timeout)
         mapping.monitoring_status = :ok
       elsif mapping.monitoring_status.ok?
           mapping.monitoring_status = :lost

--- a/lib/atmosphere.rb
+++ b/lib/atmosphere.rb
@@ -55,8 +55,9 @@ module Atmosphere
   @@config_param = Struct.new(:regexp, :range).new(/\#{\w*}/, 2..-2)
 
   mattr_reader :url_monitoring
-  @@url_monitoring = Struct.new(:unavail_statuses, :pending, :ok, :lost).
-                     new([502], 10, 120, 15)
+  @@url_monitoring = Struct.new(:unavail_statuses, :timeout,
+                                :pending, :ok, :lost).
+                     new([502], 1, 10, 120, 15)
 
   mattr_reader :optimizer
   @@optimizer = Struct.new(:max_appl_no).new(5)

--- a/spec/workers/atmosphere/endpoint_status_check_worker_spec.rb
+++ b/spec/workers/atmosphere/endpoint_status_check_worker_spec.rb
@@ -7,10 +7,11 @@ describe Atmosphere::EndpointStatusCheckWorker do
   let(:url_check) { double() }
   let(:hm) { create(:http_mapping, monitoring_status: :pending); }
   let(:hm_ok) { create(:http_mapping, monitoring_status: :ok); }
+  let(:timeout) { Atmosphere.url_monitoring.timeout }
 
   it 'should set status from pending to ok' do
     allow(url_check).to receive(:is_available)
-      .with(hm.url).and_return(true)
+      .with(hm.url, timeout).and_return(true)
 
     hm_before = Atmosphere::HttpMapping.find_by id: hm.id
     expect(hm_before.monitoring_status.pending?).to be_truthy
@@ -23,7 +24,7 @@ describe Atmosphere::EndpointStatusCheckWorker do
 
   it 'should set status from ok to lost' do
     allow(url_check).to receive(:is_available)
-      .with(hm_ok.url).and_return(false)
+      .with(hm_ok.url, timeout).and_return(false)
 
     hm_before = Atmosphere::HttpMapping.find_by id: hm_ok.id
     expect(hm_before.monitoring_status.ok?).to be_truthy
@@ -36,7 +37,7 @@ describe Atmosphere::EndpointStatusCheckWorker do
 
   it 'should leave pending' do
     allow(url_check).to receive(:is_available)
-          .with(hm.url).and_return(false)
+          .with(hm.url, timeout).and_return(false)
 
     hm_before = Atmosphere::HttpMapping.find_by id: hm.id
     expect(hm_before.monitoring_status.pending?).to be_truthy


### PR DESCRIPTION
Url checker timeout can be configured using:

```ruby
Atmosphere.setup do |config|
  config.url_monitoring.timeout = 123
end
```

@nowakowski, @tbartynski  please take a look