### PR TITLE
flavors not existing in OS but associated with a vm are marked as ina…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gemspec
 group :development do
   gem 'quiet_assets'
   gem 'web-console', '~> 3.0'
+  gem 'rubocop'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,9 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     arel (6.0.3)
+    ast (2.1.0)
+    astrolabe (1.3.1)
+      parser (~> 2.2)
     autoprefixer-rails (6.3.3.1)
       execjs
     bcrypt (3.1.11)
@@ -322,7 +325,10 @@ GEM
       hashie (>= 1.2, < 4)
       rack (>= 1.0, < 3)
     orm_adapter (0.5.0)
+    parser (2.2.2.6)
+      ast (>= 1.1, < 3.0)
     pg (0.18.4)
+    powerpack (0.1.1)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -360,6 +366,7 @@ GEM
       activesupport (= 4.2.5.2)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    rainbow (2.0.0)
     rake (10.5.0)
     rb-fsevent (0.9.5)
     rb-inotify (0.9.5)
@@ -401,6 +408,13 @@ GEM
       rspec (~> 3.0, >= 3.0.0)
       sidekiq (>= 2.4.0)
     rspec-support (3.3.0)
+    rubocop (0.32.1)
+      astrolabe (~> 1.3)
+      parser (>= 2.2.2.5, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.4)
+    ruby-progressbar (1.7.5)
     ruby_parser (3.8.1)
       sexp_processor (~> 4.1)
     sass (3.4.21)
@@ -484,6 +498,7 @@ DEPENDENCIES
   quiet_assets
   rspec-rails
   rspec-sidekiq
+  rubocop
   shoulda-matchers
   spring
   spring-commands-rspec

--- a/app/services/atmosphere/flavor_updater.rb
+++ b/app/services/atmosphere/flavor_updater.rb
@@ -21,7 +21,12 @@ module Atmosphere
     def purge_non_existing_flavors
       tenant.virtual_machine_flavors.
         where.not(id_at_site: cloud_flavors.map(&:id)).each do |flavor|
-          flavor.destroy if flavor.virtual_machines.count == 0
+          if flavor.virtual_machines.count == 0
+            flavor.destroy
+          else
+            flavor.active = false
+            flavor.save!
+          end
         end
     end
 

--- a/spec/services/atmosphere/flavor_updater_spec.rb
+++ b/spec/services/atmosphere/flavor_updater_spec.rb
@@ -3,34 +3,62 @@ require 'fog/openstack'
 
 describe Atmosphere::FlavorUpdater do
 
-  let(:t1) { create(:openstack_tenant) }
+  let(:os_tenant) { create(:openstack_tenant) }
   let(:t2) { create(:amazon_tenant) }
 
   describe 'T flavors' do
     context 'when creating a new tenant' do
       it 'registers tenants' do
-        expect(t1.virtual_machine_flavors.count).to eq 0
+        expect(os_tenant.virtual_machine_flavors.count).to eq 0
         expect(t2.virtual_machine_flavors.count).to eq 0
       end
     end
 
+    context 'flavor does not exist in cloud any longer' do
+      let!(:flavor) do
+        create(:virtual_machine_flavor, tenant: os_tenant, active: true)
+      end
+      before :each do
+        cloud_client = double('cloud client')
+        allow(cloud_client).to receive(:flavors).and_return []
+        allow(os_tenant).to receive(:cloud_client).and_return cloud_client
+      end
+      context 'no running vms using this flavor' do
+        it 'removes flavor from db' do
+          expect { Atmosphere::FlavorUpdater.new(os_tenant).execute }.
+              to change(Atmosphere::VirtualMachineFlavor, :count).by(-1)
+        end
+      end
+
+      context 'running vm uses this flavor' do
+        it 'marks flavor as inactive' do
+          create(:virtual_machine, virtual_machine_flavor: flavor)
+
+          expect do
+            Atmosphere::FlavorUpdater.new(os_tenant).execute
+            flavor.reload
+          end.to change(flavor, :active).from(true).to(false)
+        end
+      end
+    end
+
     context 'when populating a tenant with flavors' do
-      let!(:flavor6_ost) { create(:virtual_machine_flavor, tenant: t1, id_at_site: '6', flavor_name: 'foo') }
+      let!(:flavor6_ost) { create(:virtual_machine_flavor, tenant: os_tenant, id_at_site: '6', flavor_name: 'foo') }
       let!(:flavor6_aws) { create(:virtual_machine_flavor, tenant: t2, id_at_site: 'm1.medium', flavor_name: 'foo') }
 
       before do
-        create(:virtual_machine_flavor, tenant: t1, id_at_site: '5', flavor_name: 'bar')
+        create(:virtual_machine_flavor, tenant: os_tenant, id_at_site: '5', flavor_name: 'bar')
       end
 
       it 'registers tenants with flavors' do
-        expect(t1.virtual_machine_flavors.count).to eq 2
-        Atmosphere::FlavorUpdater.new(t1).execute
-        expect(t1.virtual_machine_flavors.count).to eq t1.cloud_client.flavors.count
+        expect(os_tenant.virtual_machine_flavors.count).to eq 2
+        Atmosphere::FlavorUpdater.new(os_tenant).execute
+        expect(os_tenant.virtual_machine_flavors.count).to eq os_tenant.cloud_client.flavors.count
       end
 
       it 'updates existing flavour on openstack' do
-        Atmosphere::FlavorUpdater.new(t1).execute
-        fog_flavor = t1.cloud_client.flavors.detect { |f| f.id == flavor6_ost.id_at_site }
+        Atmosphere::FlavorUpdater.new(os_tenant).execute
+        fog_flavor = os_tenant.cloud_client.flavors.detect { |f| f.id == flavor6_ost.id_at_site }
 
         flavor6_ost.reload
         expect(flavor6_ost).to flavor_eq fog_flavor
@@ -45,28 +73,28 @@ describe Atmosphere::FlavorUpdater do
       end
 
       it 'removes nonexistent flavor on openstack' do
-        Atmosphere::FlavorUpdater.new(t1).execute
-        expect(t1.virtual_machine_flavors.count).to eq t1.cloud_client.flavors.count
-        # Add nonexistent flavor to tenant t1
-        create(:virtual_machine_flavor, tenant: t1, id_at_site: 'foo', flavor_name: 'baz')
-        t1.reload
-        expect(t1.virtual_machine_flavors.where(flavor_name: 'baz').count).to eq 1
+        Atmosphere::FlavorUpdater.new(os_tenant).execute
+        expect(os_tenant.virtual_machine_flavors.count).to eq os_tenant.cloud_client.flavors.count
+        # Add nonexistent flavor to tenant os_tenant
+        create(:virtual_machine_flavor, tenant: os_tenant, id_at_site: 'foo', flavor_name: 'baz')
+        os_tenant.reload
+        expect(os_tenant.virtual_machine_flavors.where(flavor_name: 'baz').count).to eq 1
         # Scan tenant again and expect flavor "baz" to be gone
-        Atmosphere::FlavorUpdater.new(t1).execute
-        t1.reload
-        expect(t1.virtual_machine_flavors.where(flavor_name: 'baz').count).to eq 0
+        Atmosphere::FlavorUpdater.new(os_tenant).execute
+        os_tenant.reload
+        expect(os_tenant.virtual_machine_flavors.where(flavor_name: 'baz').count).to eq 0
       end
     end
 
     context 'when idle' do
       it 'scans openstack tenant' do
         # Fog creates 7 mock flavors by default
-        Atmosphere::FlavorUpdater.new(t1).execute
-        expect(t1.virtual_machine_flavors.count).to eq t1.cloud_client.flavors.count
+        Atmosphere::FlavorUpdater.new(os_tenant).execute
+        expect(os_tenant.virtual_machine_flavors.count).to eq os_tenant.cloud_client.flavors.count
 
         # No further changes expected
-        Atmosphere::FlavorUpdater.new(t1).execute
-        expect(t1.virtual_machine_flavors.count).to eq t1.cloud_client.flavors.count
+        Atmosphere::FlavorUpdater.new(os_tenant).execute
+        expect(os_tenant.virtual_machine_flavors.count).to eq os_tenant.cloud_client.flavors.count
       end
 
       it 'scans AWS tenant' do


### PR DESCRIPTION
Flavors that exist in cloud but are used by a running vm are marked as inactive.

Close #286 